### PR TITLE
Throttle / comment out spammy warnings 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-melodic-hri-safe-remote-control-system (0.2.0-bionic3) bionic; urgency=medium
+
+  * Comment out / throttle spammy warnings 
+
+ -- Steven Leonis <stevenl@greenzie.com>  Mon, 10 May 2021 11:45:54 -0400
+
 ros-melodic-hri-safe-remote-control-system (0.2.0-bionic2) bionic; urgency=medium
 
   * Fixed CMakeLists.txt to install all the necessary targets

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -306,7 +306,8 @@ void vsc_send_user_feedback(VscInterfaceType* vscInterface, uint8_t key, int32_t
 
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &feedbackMsg) < 0) {
-		fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+    // Error print commented out due to spam
+	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
 }
 
@@ -334,7 +335,8 @@ void vsc_send_user_feedback_string(VscInterfaceType* vscInterface, uint8_t key, 
 
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &feedbackMsg) < 0) {
-		fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+		// Error print commented out due to spam
+	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
 }
 
@@ -359,7 +361,8 @@ void vsc_send_heartbeat(VscInterfaceType* vscInterface, uint8_t EStopStatus) {
 
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &heartbeatMsg) < 0) {
-		fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+    // Error print commented out due to spam
+	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
 
 }

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -255,7 +255,7 @@ int VscProcess::handleHeartbeatMsg(VscMsgType& recvMsg)
 		estopPub.publish(estopValue);
 
 		if(msgPtr->EStopStatus > 0) {
-			ROS_WARN("Received ESTOP from the vehicle!!! 0x%x",msgPtr->EStopStatus);
+			ROS_WARN_THROTTLE(5.0, "Received ESTOP from the vehicle!!! 0x%x",msgPtr->EStopStatus);
 		}
 
 	} else {


### PR DESCRIPTION
This PR simply comments out / throttles a few warnings that spam the console when the SRC/VSC is ESTOP-ed or has message send failures (frequent on bootup).

Resolves [ch14870](https://app.clubhouse.io/greenzie/story/14870/need-to-throttle-e-stop-warning)