### PR TITLE
Reset display on shutdown, don't block incoming messages, remove spammy error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-melodic-hri-safe-remote-control-system (0.2.0-bionic4) bionic; urgency=medium
+
+  * Fix SRC Display on startup/shutdown bug, remove more spam 
+
+ -- Steven Leonis <stevenl@greenzie.com>  Wed, 09 Jun 2021 15:22:45 -0400
+
 ros-melodic-hri-safe-remote-control-system (0.2.0-bionic3) bionic; urgency=medium
 
   * Comment out / throttle spammy warnings 

--- a/include/JoystickHandler.h
+++ b/include/JoystickHandler.h
@@ -23,28 +23,28 @@
 #include "VehicleMessages.h"
 #include "MsgHandler.h"
 
-namespace hri_safe_remote_control_system {
+namespace hri_safe_remote_control_system
+{
+/**
+ *
+ */
+class JoystickHandler : public MsgHandler
+{
+public:
+  JoystickHandler();
+  ~JoystickHandler();
 
-	/**
-	 *
-	 */
-	class JoystickHandler : public MsgHandler {
-	   public:
-		  JoystickHandler();
-		  ~JoystickHandler();
+  uint32_t handleNewMsg(const VscMsgType& incomingMsg);
 
-		  uint32_t handleNewMsg(const VscMsgType &incomingMsg);
+private:
+  int32_t getStickValue(JoystickType joystick);
+  int32_t getButtonValue(uint8_t button);
 
-	   private:
+  ros::NodeHandle rosNode;
+  ros::Publisher rawLeftPub, rawRightPub;
+  bool useArrowsAsAxes{ false };
+};
 
-		  int32_t getStickValue(JoystickType joystick);
-		  int32_t getButtonValue(uint8_t button);
-
-		  ros::NodeHandle 		rosNode;
-		  ros::Publisher 		rawLeftPub, rawRightPub;
-		  bool 				useArrowsAsAxes{false};
-	};
-
-}
+}  // namespace hri_safe_remote_control_system
 
 #endif

--- a/include/MsgHandler.h
+++ b/include/MsgHandler.h
@@ -21,21 +21,21 @@
 #include "ros/ros.h"
 #include "VehicleMessages.h"
 
-namespace hri_safe_remote_control_system {
-
+namespace hri_safe_remote_control_system
+{
 /**
  *
  */
-class MsgHandler {
-   public:
-	  virtual ~MsgHandler() {};
+class MsgHandler
+{
+public:
+  virtual ~MsgHandler(){};
 
-	  virtual uint32_t handleNewMsg(const VscMsgType &incomingMsg) = 0;
+  virtual uint32_t handleNewMsg(const VscMsgType& incomingMsg) = 0;
 
-   private:
-
+private:
 };
 
-}
+}  // namespace hri_safe_remote_control_system
 
 #endif

--- a/include/SerialInterface.h
+++ b/include/SerialInterface.h
@@ -35,7 +35,7 @@ extern "C" {
  * @param baud Baud rate of the serial port
  * @return fd success, -1 on error
  */
-int open_serial_interface(const char *device, const unsigned int baud);
+int open_serial_interface(const char* device, const unsigned int baud);
 
 /**
  * Close the connection with the current device
@@ -51,7 +51,7 @@ void close_serial_interface(int fd);
  * @param bytes The number of bytes to write from the buffer
  * @return number of bytes written on success, -1 on error
  */
-int write_to_serial(int fd, const void *buffer, const unsigned int bytes);
+int write_to_serial(int fd, const void* buffer, const unsigned int bytes);
 
 /**
  * Read bytes from serial port
@@ -60,12 +60,10 @@ int write_to_serial(int fd, const void *buffer, const unsigned int bytes);
  * @param bytes The number of bytes to read into the buffer
  * @return number of bytes read on success, -1 on error
  */
-int read_from_serial(int fd, void *buffer,unsigned int bytes);
+int read_from_serial(int fd, void* buffer, unsigned int bytes);
 
 #ifdef __cplusplus
 }
 #endif
 
-
 #endif
-

--- a/include/VehicleInterface.h
+++ b/include/VehicleInterface.h
@@ -26,13 +26,14 @@
 extern "C" {
 #endif
 
-#define SIZE_RECEIVE_BUFFER   1000
+#define SIZE_RECEIVE_BUFFER 1000
 
-typedef struct {
-	uint32_t front;
-	uint32_t back;
-	uint32_t fd;
-	uint8_t  recvbuffer[SIZE_RECEIVE_BUFFER];
+typedef struct
+{
+  uint32_t front;
+  uint32_t back;
+  uint32_t fd;
+  uint8_t recvbuffer[SIZE_RECEIVE_BUFFER];
 } VscInterfaceType;
 
 /**
@@ -44,7 +45,7 @@ typedef struct {
  * @param baud Baud rate of serial device to open.
  * @return VSC Interface Structure if successful or NULL on error
  */
-VscInterfaceType* vsc_initialize(const char *device, const unsigned int baud);
+VscInterfaceType* vsc_initialize(const char* device, const unsigned int baud);
 
 /**
  * Cleanup the VSC interface
@@ -75,7 +76,7 @@ int32_t vsc_get_fd(VscInterfaceType* vscInterface);
  * @param sendMsg Pointer to structer with message to send to VSC.
  * @return File Descriptor of serial interface
  */
-int32_t vsc_send_msg(VscInterfaceType* vscInterface, VscMsgType *sendMsg);
+int32_t vsc_send_msg(VscInterfaceType* vscInterface, VscMsgType* sendMsg);
 
 /**
  * Read next message from the VSC
@@ -86,7 +87,7 @@ int32_t vsc_send_msg(VscInterfaceType* vscInterface, VscMsgType *sendMsg);
  * @param[out] newMsg Pointer to structure that is filled with new message from buffer.
  * @return 1 if newMsg is populated or -1 if no new messages are available
  */
-int32_t vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg);
+int32_t vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType* newMsg);
 
 /**
  * Translate joystick value from structure into integer

--- a/include/VehicleMessages.h
+++ b/include/VehicleMessages.h
@@ -35,12 +35,12 @@ extern "C" {
  ************************************************************/
 #pragma pack(1)
 
-#define VSC_MESSAGE_HEADER_1 	0x10
-#define VSC_MESSAGE_HEADER_2 	0x01
+#define VSC_MESSAGE_HEADER_1 0x10
+#define VSC_MESSAGE_HEADER_2 0x01
 
-#define VSC_MAX_MESSAGE_LENGTH 	248			/**  Maximum message length for the VSC  */
-#define VSC_HEADER_OVERHEAD 	4			/**  4 for HEADERS, MsgType, and Length  */
-#define VSC_FOOTER_OVERHEAD 	2			/**  2 for checksum						*/
+#define VSC_MAX_MESSAGE_LENGTH 248 /**  Maximum message length for the VSC  */
+#define VSC_HEADER_OVERHEAD 4      /**  4 for HEADERS, MsgType, and Length  */
+#define VSC_FOOTER_OVERHEAD 2      /**  2 for checksum						*/
 #define VSC_MIN_MESSAGE_LENGTH (VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD)
 
 #define VSC_USER_FEEDBACK_STRING_LENGTH 20
@@ -48,204 +48,223 @@ extern "C" {
 /** VSC_STATES_TYPE
  * 	The enumerated values of VSC states.
  */
-enum VSC_STATES_TYPE {
-	VSC_STATE_SEARCHING = 0x01,
-	VSC_STATE_LOCAL = 0x04,
-	VSC_STATE_OPERATIONAL = 0x09,
-	VSC_STATE_MENU = 0x0A,
-	VSC_STATE_PAUSE = 0x0B
+enum VSC_STATES_TYPE
+{
+  VSC_STATE_SEARCHING = 0x01,
+  VSC_STATE_LOCAL = 0x04,
+  VSC_STATE_OPERATIONAL = 0x09,
+  VSC_STATE_MENU = 0x0A,
+  VSC_STATE_PAUSE = 0x0B
 };
 
 /** VSC_MESSAGE_TYPE
  * 	The enumerated values of VSC messages.
  */
-enum VSC_MESSAGE_TYPE {
-	MSG_VSC_JOYSTICK = 0x10,
-	MSG_VSC_NMEA_STRING = 0x12,
-	MSG_VSC_HEARTBEAT = 0x20,
-	MSG_USER_HEARTBEAT = 0x21,
-	MSG_USER_FEEDBACK = 0x30,
-	MSG_USER_FEEDBACK_STRING = 0x31
+enum VSC_MESSAGE_TYPE
+{
+  MSG_VSC_JOYSTICK = 0x10,
+  MSG_VSC_NMEA_STRING = 0x12,
+  MSG_VSC_HEARTBEAT = 0x20,
+  MSG_USER_HEARTBEAT = 0x21,
+  MSG_USER_FEEDBACK = 0x30,
+  MSG_USER_FEEDBACK_STRING = 0x31
 };
 
 /** VSC_USER_FEEDBACK_KEY_TYPE
  * 	The enumerated values of the available user feedback keys.
  */
-enum VSC_USER_FEEDBACK_KEY_TYPE {
-	VSC_USER_FEEDBACK_KEY_1 = 1,
-	VSC_USER_FEEDBACK_KEY_2,
-	VSC_USER_FEEDBACK_KEY_3,
-	VSC_USER_FEEDBACK_KEY_4,
-	VSC_USER_FEEDBACK_KEY_5,
-	VSC_USER_FEEDBACK_KEY_6,
-	VSC_USER_FEEDBACK_KEY_7,
-	VSC_USER_FEEDBACK_KEY_8,
-	VSC_USER_FEEDBACK_KEY_9,
-	VSC_USER_LEFT_MOTOR_INTENSITY = 10,
-	VSC_USER_RIGHT_MOTOR_INTENSITY = 11,
-	VSC_USER_BOTH_MOTOR_INTENSITY = 12,
-	VSC_USER_DISPLAY_ROW_1 = 90,
-	VSC_USER_DISPLAY_ROW_2 = 91,
-	VSC_USER_DISPLAY_ROW_3 = 92,
-	VSC_USER_DISPLAY_ROW_4 = 93,
-	VSC_USER_DISPLAY_MODE = 99,
+enum VSC_USER_FEEDBACK_KEY_TYPE
+{
+  VSC_USER_FEEDBACK_KEY_1 = 1,
+  VSC_USER_FEEDBACK_KEY_2,
+  VSC_USER_FEEDBACK_KEY_3,
+  VSC_USER_FEEDBACK_KEY_4,
+  VSC_USER_FEEDBACK_KEY_5,
+  VSC_USER_FEEDBACK_KEY_6,
+  VSC_USER_FEEDBACK_KEY_7,
+  VSC_USER_FEEDBACK_KEY_8,
+  VSC_USER_FEEDBACK_KEY_9,
+  VSC_USER_LEFT_MOTOR_INTENSITY = 10,
+  VSC_USER_RIGHT_MOTOR_INTENSITY = 11,
+  VSC_USER_BOTH_MOTOR_INTENSITY = 12,
+  VSC_USER_DISPLAY_ROW_1 = 90,
+  VSC_USER_DISPLAY_ROW_2 = 91,
+  VSC_USER_DISPLAY_ROW_3 = 92,
+  VSC_USER_DISPLAY_ROW_4 = 93,
+  VSC_USER_DISPLAY_MODE = 99,
 };
 
 /** VscMsgData
  * 	The union for data that is sent and received to the VSC.  This contains
  * 	the 16-bit header, message type, length, data fields and fletcher checksum.
  */
-typedef union {
-	uint8_t  buffer[VSC_MAX_MESSAGE_LENGTH + VSC_HEADER_OVERHEAD];
-	struct {
-		uint8_t  header_1;
-		uint8_t  header_2;
-		uint8_t  msgType;
-		uint8_t  length;
-		uint8_t  data[VSC_MAX_MESSAGE_LENGTH];
-	};
+typedef union
+{
+  uint8_t buffer[VSC_MAX_MESSAGE_LENGTH + VSC_HEADER_OVERHEAD];
+  struct
+  {
+    uint8_t header_1;
+    uint8_t header_2;
+    uint8_t msgType;
+    uint8_t length;
+    uint8_t data[VSC_MAX_MESSAGE_LENGTH];
+  };
 } VscMsgData;
 
 /** VscMsgType
  * 	The Structure for data that is sent and received by the VSC.
  */
-typedef struct {
-	VscMsgData  msg;
+typedef struct
+{
+  VscMsgData msg;
 } VscMsgType;
 
 /** JOYSTICK_STATUS_TYPE
  * 	The enumerated values of the joystick status values.
  */
-enum JOYSTICK_STATUS_TYPE {
-	STATUS_NOT_RECOGNIZED = 0x0,
-	STATUS_SET = 0x1,
-	STATUS_ERROR = 0x2,
-	STATUS_NOT_AVAILABLE = 0x3
+enum JOYSTICK_STATUS_TYPE
+{
+  STATUS_NOT_RECOGNIZED = 0x0,
+  STATUS_SET = 0x1,
+  STATUS_ERROR = 0x2,
+  STATUS_NOT_AVAILABLE = 0x3
 };
 
 /** SwitchType
  * 	The Structure for the 1 byte packed data of the joystick button value.
  */
-typedef struct {
-	uint8_t home:2;				/* JOYSTICK_STATUS_TYPE */
-	uint8_t first:2;			/* JOYSTICK_STATUS_TYPE */
-	uint8_t second:2;			/* JOYSTICK_STATUS_TYPE */
-	uint8_t third:2;			/* JOYSTICK_STATUS_TYPE */
+typedef struct
+{
+  uint8_t home : 2;   /* JOYSTICK_STATUS_TYPE */
+  uint8_t first : 2;  /* JOYSTICK_STATUS_TYPE */
+  uint8_t second : 2; /* JOYSTICK_STATUS_TYPE */
+  uint8_t third : 2;  /* JOYSTICK_STATUS_TYPE */
 } SwitchType;
 
 /** JoystickType
  * 	The Structure for the 2 byte packed data of the joystick axis value.
  */
-typedef struct {
-	uint8_t neutral_status:2;	/* JOYSTICK_STATUS_TYPE */
-	uint8_t negative_status:2;	/* JOYSTICK_STATUS_TYPE */
-	uint8_t positive_status:2;	/* JOYSTICK_STATUS_TYPE */
-	uint8_t mag_lsb:2;
-	uint8_t magnitude;
+typedef struct
+{
+  uint8_t neutral_status : 2;  /* JOYSTICK_STATUS_TYPE */
+  uint8_t negative_status : 2; /* JOYSTICK_STATUS_TYPE */
+  uint8_t positive_status : 2; /* JOYSTICK_STATUS_TYPE */
+  uint8_t mag_lsb : 2;
+  uint8_t magnitude;
 } JoystickType;
 
 /** JoystickMsgType
  * 	The Structure for the packed joystick message that is received from the VSC.
  */
-typedef struct {
-	JoystickType leftX;
-	JoystickType leftY;
-	JoystickType leftZ;
-	JoystickType rightX;
-	JoystickType rightY;
-	JoystickType rightZ;
-	SwitchType   leftSwitch;
-	SwitchType   rightSwitch;
+typedef struct
+{
+  JoystickType leftX;
+  JoystickType leftY;
+  JoystickType leftZ;
+  JoystickType rightX;
+  JoystickType rightY;
+  JoystickType rightZ;
+  SwitchType leftSwitch;
+  SwitchType rightSwitch;
 } JoystickMsgType;
 
 /** ESTOP_STATUS_TYPE
  * 	The enumerated values of the emergency stop values.
  */
-enum ESTOP_STATUS_TYPE {
-	ESTOP_STATUS_NOT_SET = 0x0,
-	ESTOP_STATUS_ACTIVATED = 0x1
+enum ESTOP_STATUS_TYPE
+{
+  ESTOP_STATUS_NOT_SET = 0x0,
+  ESTOP_STATUS_ACTIVATED = 0x1
 };
 
 /** EstopStatusType
  * 	The Structure for the 1 byte packed data of the joystick button value.
  */
-typedef union {
-	struct {
-		uint8_t SRC:2;
-		uint8_t VSC:2;
-		uint8_t RSVD:2;
-		uint8_t USER:2;
-		uint8_t RSVD_2;
-		uint8_t RSVD_3;
-		uint8_t RSVD_4;
-	} bits;
-	uint32_t bytes;
+typedef union
+{
+  struct
+  {
+    uint8_t SRC : 2;
+    uint8_t VSC : 2;
+    uint8_t RSVD : 2;
+    uint8_t USER : 2;
+    uint8_t RSVD_2;
+    uint8_t RSVD_3;
+    uint8_t RSVD_4;
+  } bits;
+  uint32_t bytes;
 } EstopStatusType;
 
 /** UserHeartbeatMsgType
  * 	The Structure for the packed heartbeat message that is sent to the VSC.
  */
-typedef struct {
-	uint8_t EStopStatus;
+typedef struct
+{
+  uint8_t EStopStatus;
 } UserHeartbeatMsgType;
 
 /** HeartbeatMsgType
  * 	The Structure for the packed heartbeat message that is received from the VSC.
  */
-typedef struct {
-	uint8_t VscMode;
-	uint8_t AutonomonyMode;
-	uint32_t EStopStatus;
+typedef struct
+{
+  uint8_t VscMode;
+  uint8_t AutonomonyMode;
+  uint32_t EStopStatus;
 } HeartbeatMsgType;
 
 /** GpsMsgType
  * 	The Structure for the packed gps message that is received from the VSC.
  */
-typedef struct {
-	uint8_t source;
-	uint8_t data[VSC_MAX_MESSAGE_LENGTH-1];
+typedef struct
+{
+  uint8_t source;
+  uint8_t data[VSC_MAX_MESSAGE_LENGTH - 1];
 } GpsMsgType;
 
 /** UserFeedbackMsgType
  * 	The Structure for the packed key value pair that is used to transmit the user
  * 	feedback data to the VSC.
  */
-typedef struct {
-	uint8_t key;
-	int32_t value;
+typedef struct
+{
+  uint8_t key;
+  int32_t value;
 } UserFeedbackMsgType;
 
 /** UserFeedbackStringMsgType
  * 	The Structure for the packed key value pair that is used to transmit the user
  * 	feedback data to the VSC.
  */
-typedef struct {
-	uint8_t key;
-	char value[VSC_USER_FEEDBACK_STRING_LENGTH];
+typedef struct
+{
+  uint8_t key;
+  char value[VSC_USER_FEEDBACK_STRING_LENGTH];
 } UserFeedbackStringMsgType;
 
 /** MOTOR_INTENSITY_TYPE
- * 	The enumerated values of the motor control intensities 
+ * 	The enumerated values of the motor control intensities
  */
-enum DISPLAY_MODE_TYPE {
-        DISPLAY_MODE_STANDARD = 0,
-        DISPLAY_MODE_CUSTOM_TEXT,
-        DISPLAY_MODE_TEXT_VALUE,
-        DISPLAY_MODE_VALUES
+enum DISPLAY_MODE_TYPE
+{
+  DISPLAY_MODE_STANDARD = 0,
+  DISPLAY_MODE_CUSTOM_TEXT,
+  DISPLAY_MODE_TEXT_VALUE,
+  DISPLAY_MODE_VALUES
 };
 
 /** MOTOR_INTENSITY_TYPE
- * 	The enumerated values of the motor control intensities 
+ * 	The enumerated values of the motor control intensities
  */
-enum MOTOR_INTENSITY_TYPE {
-        MOTOR_CONTROL_INTENSITY_OFF = 0,
-        MOTOR_CONTROL_INTENSITY_HIGH = 1,
-        MOTOR_CONTROL_INTENSITY_MAX
+enum MOTOR_INTENSITY_TYPE
+{
+  MOTOR_CONTROL_INTENSITY_OFF = 0,
+  MOTOR_CONTROL_INTENSITY_HIGH = 1,
+  MOTOR_CONTROL_INTENSITY_MAX
 };
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif

--- a/include/VscProcess.h
+++ b/include/VscProcess.h
@@ -70,7 +70,6 @@ namespace hri_safe_remote_control_system {
 
 		  void readFromVehicle();
 		  int handleHeartbeatMsg(VscMsgType& recvMsg);
-		  hri_safe_remote_control_system::SrcDisplay prev_msg_;
 
 		  // Local State
 		  uint32_t 				myEStopState;

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -266,7 +266,6 @@ void VscProcess::readFromVehicle()
 			break;
 		default:
 			errorCounts.invalidRxMsgCount++;
-			ROS_ERROR("Receive Error.  Invalid MsgType (0x%02X)",recvMsg.msg.msgType);
 			break;
 		}
 	}

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -101,7 +101,11 @@ VscProcess::VscProcess() :
 
 VscProcess::~VscProcess()
 {
-    // Destroy vscInterface
+  // before destroying, reset the SRC display for next time
+  std_msgs::EmptyConstPtr clear_msg;
+  receivedDisplayOffCommand(clear_msg);
+
+  // Destroy vscInterface
 	vsc_cleanup(vscInterface);
 
 	if(joystickHandler) delete joystickHandler;

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -142,51 +142,23 @@ void VscProcess::checkCharacterLimit(const hri_safe_remote_control_system::SrcDi
 }
 
 void VscProcess::receivedDisplayOnCommand(const hri_safe_remote_control_system::SrcDisplay& msg)
-{	
-	// Save the first message we receive as the previous message
-	static bool msg_received = false;
-
+{
 	// Turn on custom display mode
 	vsc_send_user_feedback(vscInterface, VSC_USER_DISPLAY_MODE, DISPLAY_MODE_CUSTOM_TEXT);
 
-	if (!msg_received)
-	{
-		prev_msg_ = msg;
-		msg_received = true;
+  // Checks if the display messages are below the MAXCHARACTERS limit
+  checkCharacterLimit(msg);
 
-		// Checks if the display messages are below the MAXCHARACTERS limit
-		checkCharacterLimit(prev_msg_);
-
-		// Update Display messages
-		vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_1, msg.displayrow1.c_str());
-		vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_2, msg.displayrow2.c_str());
-		vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_3, msg.displayrow3.c_str());
-		vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_4, msg.displayrow4.c_str());
-		return;
-	}
-
-	// Checks if the display messages are below the MAXCHARACTERS limit
-	checkCharacterLimit(msg);
-
-	// Only send a display message if it is different from the previous message
-
+  // Update Display messages
   vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_1, msg.displayrow1.c_str());
-
-
   vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_2, msg.displayrow2.c_str());
-
-
   vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_3, msg.displayrow3.c_str());
-
   vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_4, msg.displayrow4.c_str());
 
-
-	// Save the previous message
-	prev_msg_ = msg;
 }
 
 void VscProcess::receivedDisplayOffCommand(const std_msgs::EmptyConstPtr& msg)
-{	
+{
 	hri_safe_remote_control_system::SrcDisplay clear_msg;
 	clear_msg.displayrow1 = clear_msg.displayrow2 = clear_msg.displayrow3 = clear_msg.displayrow4 = "";
 	vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_1, clear_msg.displayrow1.c_str());
@@ -194,9 +166,6 @@ void VscProcess::receivedDisplayOffCommand(const std_msgs::EmptyConstPtr& msg)
 	vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_3, clear_msg.displayrow3.c_str());
 	vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_4, clear_msg.displayrow4.c_str());
 	vsc_send_user_feedback(vscInterface, VSC_USER_DISPLAY_MODE, DISPLAY_MODE_STANDARD);
-
-	// Save the clear message as previous
-	prev_msg_ = clear_msg;
 
 }
 

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -169,22 +169,17 @@ void VscProcess::receivedDisplayOnCommand(const hri_safe_remote_control_system::
 	checkCharacterLimit(msg);
 
 	// Only send a display message if it is different from the previous message
-	if(msg.displayrow1 != prev_msg_.displayrow1)
-	{
-		vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_1, msg.displayrow1.c_str());
-	}
-	if(msg.displayrow2 != prev_msg_.displayrow2)
-	{
-		vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_2, msg.displayrow2.c_str());
-	}
-	if(msg.displayrow3 != prev_msg_.displayrow3)
-	{
-		vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_3, msg.displayrow3.c_str());
-	}
-	if(msg.displayrow4 != prev_msg_.displayrow4)
-	{
-		vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_4, msg.displayrow4.c_str());
-	}
+
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_1, msg.displayrow1.c_str());
+
+
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_2, msg.displayrow2.c_str());
+
+
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_3, msg.displayrow3.c_str());
+
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_4, msg.displayrow4.c_str());
+
 
 	// Save the previous message
 	prev_msg_ = msg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,24 +15,23 @@
 #include "ros/ros.h"
 #include "VscProcess.h"
 
-hri_safe_remote_control_system::VscProcess *VSCInterface;
+hri_safe_remote_control_system::VscProcess* VSCInterface;
 
 /**
  * VSC Vehicle Interface
  */
-int main(int argc, char **argv) {
-	ros::init(argc, argv, "VscProcess");
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "VscProcess");
 
-	// Create vehicle interface
-	VSCInterface = new hri_safe_remote_control_system::VscProcess();
+  // Create vehicle interface
+  VSCInterface = new hri_safe_remote_control_system::VscProcess();
 
-	// Allow ROS to handle timing and callbacks
-	ros::spin();
+  // Allow ROS to handle timing and callbacks
+  ros::spin();
 
-	// Application ending
-	delete VSCInterface;
+  // Application ending
+  delete VSCInterface;
 
-	return 0;
+  return 0;
 }
-
-


### PR DESCRIPTION
This PR resolves [ch15578](https://app.clubhouse.io/greenzie/story/15578/fix-src-text-display-on-startup) and [ch15687](https://app.clubhouse.io/greenzie/story/15687/suppress-receive-error-invalid-msg-type-output) 

The issue was that if the SRC was set to VSC_USER_DISPLAY_MODE, but the `prev_msg_` was the same, it would get set to the custom display mode with no custom text, which led to it saying "DISPLAY 1" down to "DISPLAY 4". I fixed this by removing the `prev_msg_` checks. I don't think it was really useful anyways, as I don't think we really care about sending a lot of messages through the SRC/VSC. 

I also, while testing, fixed another small issue where the SRC wouldn't leave VSC_USER_DISPLAY_MODE when plaut was shut down, so now it does upon node shutdown. It is extremely unlikely that a user would have encountered this issue, but it's useful for devs.

Also, I removed an annoying ERROR message that we couldn't do anything about.