### PR TITLE
Jonathansanabria/create node to monitor sapcorda spy data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,11 @@ target_link_libraries(safe_remote_control
         ${catkin_LIBRARIES}
 )
 
+include_directories(
+    include
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
 ## Mark executables and/or libraries for installation
 install(TARGETS safe_remote_control
                 ${PROJECT_NAME}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ros-melodic-hri-safe-remote-control-system (0.2.0-bionic6) bionic; urgency=medium
+
+  * allowing other packages to use hri include directory,
+    SerialInterface.h used in greenzie_hardware for sapcorda monitor
+    node.
+
+ -- Jonathan Sanabria <jonathan@greenzie.com>  Tue, 15 Jun 2021 17:53:38 -0400
+
 ros-melodic-hri-safe-remote-control-system (0.2.0-bionic5) bionic; urgency=medium
 
   * Fix SRC Display on startup/shutdown bug, remove more spam 


### PR DESCRIPTION
This PR helps resolve [15890](https://app.clubhouse.io/greenzie/story/15890/create-node-to-monitor-sapcorda-spy-data) :

The package is being updated because rather than rewriting the SerialInterface provided by the package, OR rather than including a whole new package named serial. the Sapcorda node can happily use SerialInterface.h after it is exported into CATKIN_PACKAGE_INCLUDE_DESTINATION .