### PR TITLE
Automatically attempt to reconnect to VSC if node loses connection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(catkin REQUIRED
         roscpp
         std_msgs
         sensor_msgs
-        greenzie_common
         genmsg
         message_runtime
         message_generation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED
         roscpp
         std_msgs
         sensor_msgs
+        greenzie_common
         genmsg
         message_runtime
         message_generation

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-melodic-hri-safe-remote-control-system (0.2.0-bionic6) bionic; urgency=medium
+
+  * Automatically reconnect to VSC if disconnected 
+
+ -- Steven Leonis <stevenl@greenzie.com>  Wed, 16 Jun 2021 15:32:00 -0400
+
 ros-melodic-hri-safe-remote-control-system (0.2.0-bionic5) bionic; urgency=medium
 
   * Fix SRC Display on startup/shutdown bug, remove more spam 

--- a/include/VscProcess.h
+++ b/include/VscProcess.h
@@ -21,7 +21,6 @@
 #include "ros/ros.h"
 #include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
-#include <actionlib/server/simple_action_server.h>
 
 #include "hri_safe_remote_control_system/EmergencyStop.h"
 #include "hri_safe_remote_control_system/KeyValue.h"
@@ -76,6 +75,8 @@ private:
   // Local State
   uint32_t myEStopState;
   ErrorCounterType errorCounts;
+  std::string serial_port_ = "/dev/ttyACM0";
+  int serial_speed_ = 115200;
 
   // ROS
   ros::NodeHandle rosNode;

--- a/launch/vsc_interface.launch
+++ b/launch/vsc_interface.launch
@@ -7,7 +7,8 @@
         <node name="vsc_serial_interface"
               pkg="hri_safe_remote_control_system"
               type="safe_remote_control"
-              respawn="true">
+              respawn="true"
+              respawn_delay="1">
           <param name="port" value="$(arg safety_port)"/>
           <param name="useArrowsAsAxes" type="bool" value="false"/>
         </node>

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -41,27 +41,25 @@ using namespace hri_safe_remote_control_system;
 VscProcess::VscProcess() : myEStopState(0)
 {
   ros::NodeHandle nh("~");
-  std::string serialPort = "/dev/ttyACM0";
-  if (nh.getParam("port", serialPort))
+  if (nh.getParam("port", serial_port_))
   {
-    ROS_INFO("Serial Port updated to:  %s", serialPort.c_str());
+    ROS_INFO("Serial Port updated to:  %s", serial_port_.c_str());
   }
 
-  int serialSpeed = 115200;
-  if (nh.getParam("serial_speed", serialSpeed))
+  if (nh.getParam("serial_speed", serial_speed_))
   {
-    ROS_INFO("Serial Port Speed updated to:  %i", serialSpeed);
+    ROS_INFO("Serial Port Speed updated to:  %i", serial_speed_);
   }
 
   /* Open VSC Interface */
-  vscInterface = vsc_initialize(serialPort.c_str(), serialSpeed);
+  vscInterface = vsc_initialize(serial_port_.c_str(), serial_speed_);
   if (vscInterface == NULL)
   {
-    ROS_FATAL("Cannot open serial port! (%s, %i)", serialPort.c_str(), serialSpeed);
+    ROS_FATAL("Cannot open serial port! (%s, %i)", serial_port_.c_str(), serial_speed_);
   }
   else
   {
-    ROS_INFO("Connected to VSC on %s : %i", serialPort.c_str(), serialSpeed);
+    ROS_INFO("Connected to VSC on %s : %i", serial_port_.c_str(), serial_speed_);
   }
 
   // Attempt to Set priority
@@ -290,5 +288,17 @@ void VscProcess::readFromVehicle()
   if (noDataDuration > ros::Duration(.25))
   {
     ROS_WARN_THROTTLE(.5, "No Data Received in %i.%09i seconds", noDataDuration.sec, noDataDuration.nsec);
+    ROS_WARN_STREAM("Attempting to reconnect to the VSC...");
+    /* Open VSC Interface */
+    vscInterface = vsc_initialize(serial_port_.c_str(), serial_speed_);
+    if (vscInterface == NULL)
+    {
+      ROS_FATAL("Cannot open serial port! (%s, %i)", serial_port_.c_str(), serial_speed_);
+    }
+    else
+    {
+      ROS_INFO("Connected to VSC on %s : %i", serial_port_.c_str(), serial_speed_);
+    }
+    // On fail, we expect a crash at the moment. This will mean that the node respawns
   }
 }


### PR DESCRIPTION
This PR simply adds a repeat of the "initialize VSC" step of the constructor for `VscProcess` to a check at the end of `readFromVehicle()`. When `readFromVehicle()` detects that it hasn't received anything from the VSC for a while, we assume that the VSC is disconnected, so we attempt a reconnect.

At the moment, this will almost certainly result in a segfault due to improperly freeing memory in `VehicleInterface.c`. However, I was unable to figure out how to fix this issue. So, in the result of a crash, the node will respawn (with a delay of 1 second), and attempt to reconnect again in the new `VscProcess` constructor, which is acceptable if not preferable.

Resolves [ch15587](https://app.clubhouse.io/greenzie/story/15887/dig-in-to-vsc-src-issues)