### PR TITLE
Jonathansanabria/sc 17868/update vscprocess to log src and vehicle

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-melodic-hri-safe-remote-control-system (0.2.0-bionic10) bionic; urgency=medium
+
+  * Update VscProcess to distinguish between Estop sources when logging. 
+
+ -- Jonathan Sanabria <jonathan@greenzie.com>  Mon, 20 Sep 2021 13:30:10 -0400
+
 ros-melodic-hri-safe-remote-control-system (0.2.0-bionic9) bionic; urgency=medium
 
   * Update install directory

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -227,10 +227,23 @@ int VscProcess::handleHeartbeatMsg(VscMsgType& recvMsg)
     std_msgs::UInt32 estopValue;
     estopValue.data = msgPtr->EStopStatus;
     estopPub.publish(estopValue);
-
-    if (msgPtr->EStopStatus > 0)
+    bool estop_vehicle = (msgPtr->EStopStatus >> 2) & 0x01;
+    bool estop_src = msgPtr->EStopStatus & 0x01;
+    if (estop_vehicle && estop_src)
+    {
+      ROS_WARN_THROTTLE(5.0, "Received ESTOP from the vehicle and SRC!!! 0x%x", msgPtr->EStopStatus);
+    }
+    else if (estop_vehicle)
     {
       ROS_WARN_THROTTLE(5.0, "Received ESTOP from the vehicle!!! 0x%x", msgPtr->EStopStatus);
+    }
+    else if (estop_src)
+    {
+      ROS_WARN_THROTTLE(5.0, "Received ESTOP from the SRC!!! 0x%x", msgPtr->EStopStatus);
+    }
+    else if (msgPtr->EStopStatus > 0)
+    {
+      ROS_WARN_THROTTLE(5.0, "Unknown ESTOP signal on Vsc!!! 0x%x", msgPtr->EStopStatus);
     }
   }
   else


### PR DESCRIPTION
this PR solves [17868](https://app.shortcut.com/greenzie/stories/space/16066/owned-by-me)

Line 231 of VscProcess.cpp does not currently distinguish between Vehicle and SRC Estop. Even though intrepid Control Translator shows that we can distinguish the Estop sources. 

TODO, test correct logging of Estop source from VscProcess.