### PR TITLE
Jonathansanabria/sc 17872/add a src health monitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_message_files(
         DIRECTORY msg
         FILES
         SrcDisplay.msg
+        FortHealth.msg
 )
 
 generate_messages(

--- a/include/hri_safe_remote_control_system/VehicleMessages.h
+++ b/include/hri_safe_remote_control_system/VehicleMessages.h
@@ -170,20 +170,6 @@ typedef struct
   SwitchType rightSwitch;
 } JoystickMsgType;
 
-/** RemoteStatusMsgType
- * 	The union for Remote Status Messages.  This contains
- * 	the 16-bit header, message type, length, data fields and fletcher checksum.
- */
-typedef struct
-{
-  uint8_t battery_level;    // 1-100%, in 10% increments
-  uint8_t battery_charging;    // 0/1 "bool"
-  uint8_t connection_strength_vsc; // low 0/1/2 high : as percieved by VSC
-  uint8_t connection_strength_src; // low 0/1/2 high : as percieved by SRC
-  uint8_t rssi_vsc; // documentation says "Reserved for future use"
-  uint8_t rssi_src; // documentation says "Reserved for future use"
-} RemoteStatusMsgType;
-
 /** ESTOP_STATUS_TYPE
  * 	The enumerated values of the emergency stop values.
  */

--- a/include/hri_safe_remote_control_system/VehicleMessages.h
+++ b/include/hri_safe_remote_control_system/VehicleMessages.h
@@ -59,6 +59,7 @@ enum VSC_STATES_TYPE
 
 /** VSC_MESSAGE_TYPE
  * 	The enumerated values of VSC messages.
+ * https://hriwiki.atlassian.net/wiki/spaces/DOC/pages/44826637/SCM+Interface#SCMInterface-RemoteStatusMessage%3A0x22(FromVSC)
  */
 enum VSC_MESSAGE_TYPE
 {
@@ -66,6 +67,7 @@ enum VSC_MESSAGE_TYPE
   MSG_VSC_NMEA_STRING = 0x12,
   MSG_VSC_HEARTBEAT = 0x20,
   MSG_USER_HEARTBEAT = 0x21,
+  MSG_USER_REMOTE_STATUS = 0x22,
   MSG_USER_FEEDBACK = 0x30,
   MSG_USER_FEEDBACK_STRING = 0x31
 };
@@ -167,6 +169,20 @@ typedef struct
   SwitchType leftSwitch;
   SwitchType rightSwitch;
 } JoystickMsgType;
+
+/** RemoteStatusMsgType
+ * 	The union for Remote Status Messages.  This contains
+ * 	the 16-bit header, message type, length, data fields and fletcher checksum.
+ */
+typedef struct
+{
+  uint8_t battery_level;    // 1-100%, in 10% increments
+  uint8_t battery_charging;    // 0/1 "bool"
+  uint8_t connection_strength_vsc; // low 0/1/2 high : as percieved by VSC
+  uint8_t connection_strength_src; // low 0/1/2 high : as percieved by SRC
+  uint8_t rssi_vsc; // documentation says "Reserved for future use"
+  uint8_t rssi_src; // documentation says "Reserved for future use"
+} RemoteStatusMsgType;
 
 /** ESTOP_STATUS_TYPE
  * 	The enumerated values of the emergency stop values.

--- a/include/hri_safe_remote_control_system/VscProcess.h
+++ b/include/hri_safe_remote_control_system/VscProcess.h
@@ -25,7 +25,8 @@
 #include "hri_safe_remote_control_system/EmergencyStop.h"
 #include "hri_safe_remote_control_system/KeyValue.h"
 #include "hri_safe_remote_control_system/KeyString.h"
-#include <hri_safe_remote_control_system/SrcDisplay.h>
+#include "hri_safe_remote_control_system/SrcDisplay.h"
+#include "hri_safe_remote_control_system/FortHealth.h"
 
 /**
  * HRI_COMMON Includes
@@ -70,7 +71,6 @@ public:
 
 private:
   void readFromVehicle();
-  void uIntRosPub(ros::Publisher* pubPtr, uint32_t value);
   int handleHeartbeatMsg(VscMsgType& recvMsg);
   int handleRemoteStatusMsg(VscMsgType& recvMsg);
 
@@ -79,17 +79,16 @@ private:
   ErrorCounterType errorCounts;
   std::string serial_port_ = "/dev/ttyACM0";
   int serial_speed_ = 115200;
+  
+  // cached
+  uint8_t latest_vsc_mode_{0};
 
   // ROS
   ros::NodeHandle rosNode;
   ros::Timer mainLoopTimer;
   ros::ServiceServer estopServ, keyValueServ, keyStringServ;
   ros::Publisher estopPub;
-  ros::Publisher vscModePub; // 0x20 MSG_VSC_HEARTBEAT 0/4/6/9/10/11
-  ros::Publisher batteryLevelPub;      // int
-  ros::Publisher batteryChargingPub;   // bool
-  ros::Publisher vscConnectionStrengthPub;  // 0/1/2 == low/med/high : as percieved by vsc
-  ros::Publisher srcConnectionStrengthPub;  // 0/1/2 == low/med/high : as percieved by src
+  ros::Publisher safetyHealthPub;
   ros::Subscriber vibrateSrcSub;
   ros::Subscriber displaySrcOnSub;
   ros::Subscriber displaySrcOffSub;
@@ -97,6 +96,7 @@ private:
 
   // Message Handlers
   MsgHandler* joystickHandler;
+  FortHealth* safetyHealthMsg;
 
   /* File descriptor for VSC Interface */
   VscInterfaceType* vscInterface;

--- a/include/hri_safe_remote_control_system/VscProcess.h
+++ b/include/hri_safe_remote_control_system/VscProcess.h
@@ -70,7 +70,9 @@ public:
 
 private:
   void readFromVehicle();
+  void uIntRosPub(ros::Publisher* pubPtr, uint32_t value);
   int handleHeartbeatMsg(VscMsgType& recvMsg);
+  int handleRemoteStatusMsg(VscMsgType& recvMsg);
 
   // Local State
   uint32_t myEStopState;
@@ -83,6 +85,11 @@ private:
   ros::Timer mainLoopTimer;
   ros::ServiceServer estopServ, keyValueServ, keyStringServ;
   ros::Publisher estopPub;
+  ros::Publisher vscModePub; // 0x20 MSG_VSC_HEARTBEAT 0/4/6/9/10/11
+  ros::Publisher batteryLevelPub;      // int
+  ros::Publisher batteryChargingPub;   // bool
+  ros::Publisher vscConnectionStrengthPub;  // 0/1/2 == low/med/high : as percieved by vsc
+  ros::Publisher srcConnectionStrengthPub;  // 0/1/2 == low/med/high : as percieved by src
   ros::Subscriber vibrateSrcSub;
   ros::Subscriber displaySrcOnSub;
   ros::Subscriber displaySrcOffSub;

--- a/msg/FortHealth.msg
+++ b/msg/FortHealth.msg
@@ -1,9 +1,9 @@
-uint8 battery_level               # 1-100%, in 10% increments
-bool battery_charging             # 0/1 "bool"
-uint8 connection_strength_vsc     # low 0/1/2 high : as percieved by VSC
-uint8 connection_strength_src     # low 0/1/2 high : as percieved by SRC
-uint8 rssi_vsc                    # documentation says "Reserved for future use"
-uint8 rssi_src                    # documentation says "Reserved for future use"
+uint8 src_battery_level           # 1-100%, in 10% increments
+bool  src_battery_charging        # 0/1 "bool"
+uint8 vsc_connection_strength     # low 0/1/2 high : as percieved by VSC
+uint8 src_connection_strength     # low 0/1/2 high : as percieved by SRC
+uint8 vsc_rssi                    # documentation says "Reserved for future use"
+uint8 src_rssi                    # documentation says "Reserved for future use"
 uint8 vsc_mode  # 0 = Error
                 # 4 = Local/Searching
                 # 6 = Remote Connected

--- a/msg/FortHealth.msg
+++ b/msg/FortHealth.msg
@@ -1,0 +1,12 @@
+uint8 battery_level               # 1-100%, in 10% increments
+bool battery_charging             # 0/1 "bool"
+uint8 connection_strength_vsc     # low 0/1/2 high : as percieved by VSC
+uint8 connection_strength_src     # low 0/1/2 high : as percieved by SRC
+uint8 rssi_vsc                    # documentation says "Reserved for future use"
+uint8 rssi_src                    # documentation says "Reserved for future use"
+uint8 vsc_mode  # 0 = Error
+                # 4 = Local/Searching
+                # 6 = Remote Connected
+                # 9 = Remote Operational
+                # 10 = Menu
+                # 11 = Pause


### PR DESCRIPTION
This PR partly resolves [17872](https://app.shortcut.com/greenzie/story/17872/add-a-src-health-monitor) 

The rest of the story will (as discussed in the above story) be resolved when the information is logged to the system_status csv [17890](https://app.shortcut.com/greenzie/story/17890/log-src-health-information-to-csv) .

[Remote Status Message: 0x22](https://hriwiki.atlassian.net/wiki/spaces/DOC/pages/44826637/SCM+Interface#SCMInterface-RemoteStatusMessage%3A0x22(FromVSC))
The PR gets SRC health information and publishes it to :
* ```safety/src/battery/level```
* ```safety/src/battery/is_charging```
* ```safety/vsc/connection_strength```
* ```safety/src/connection_strength```

[VSC Heartbeat Message: 0x20](https://hriwiki.atlassian.net/wiki/spaces/DOC/pages/44826637/SCM+Interface#SCMInterface-VSCHeartbeatMessage%3A0x20(FromVSC))
Furthermore we easily publish VSC mode/status through the same heartbeat we get Estop statuses :
* ```safety/vsc/mode```
@edavies64 do agree/disagree that publishing the VSC mode could help debug?

TODO : test functionality (hoping to get some comments and edits in before testing)
