### PR TITLE
add SRC vibration when 'battery-charging-state' changes.

### DIFF
--- a/include/hri_safe_remote_control_system/VscProcess.h
+++ b/include/hri_safe_remote_control_system/VscProcess.h
@@ -82,6 +82,7 @@ private:
   
   // cached
   uint8_t latest_vsc_mode_{ 0 };
+  uint8_t prev_src_charging_state_{ 0 };
 
   // ROS
   ros::NodeHandle rosNode;

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -278,6 +278,12 @@ int VscProcess::handleRemoteStatusMsg(VscMsgType& recvMsg)
     srcHealthMsg = (SrcHealth*)recvMsg.msg.data;
     srcHealthMsg->vsc_mode = latest_vsc_mode_;
     srcHealthPub.publish(*srcHealthMsg);
+
+    if (srcHealthMsg->src_battery_charging != prev_src_charging_state_)
+    {
+      vsc_send_user_feedback(vscInterface, VSC_USER_BOTH_MOTOR_INTENSITY, MOTOR_CONTROL_INTENSITY_HIGH);
+    }
+    prev_src_charging_state_ = srcHealthMsg->src_battery_charging;
   }
   else
   {


### PR DESCRIPTION
This PR addresses [17929](https://app.shortcut.com/greenzie/story/17929/add-src-vibration-when-battery-charging-state-changes)

The PR is meant to probe opinions on whether we should implement a way to vibrate the SRC when it is put to charge.
The idea being that it'll be easier for operators to know when the SRC is on and plugged in correctly.

**I've implemented what I think could easily give the above functionality but haven't invested much more time into it** (in case others don't think that : vibrating the SRC, only when it's on, and when the charging status changes [ _status updates at 1hz intervals_ ], is a good idea.)

The reason I think it may NOT be a good idea is that : since it would only vibrate when the SRC is on, THEN an operator might get confused if plugging it in doesn't cause vibrations when the controller is off.

Note : 
- Untested
- Vibrations are only expected when the SRC is on and communicating to the VSC.