### PR TITLE
VSC Hardware Native Settings Grabbing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ find_package(catkin REQUIRED
         genmsg
         message_runtime
         message_generation
-        bond
-        bondcpp
 )
 
 include_directories(
@@ -23,6 +21,7 @@ add_service_files(
         EmergencyStop.srv
         KeyString.srv
         KeyValue.srv
+        GetVscSettings.srv
 )
 
 add_message_files(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED
         genmsg
         message_runtime
         message_generation
+        bond
         bondcpp
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED
         genmsg
         message_runtime
         message_generation
+        bondcpp
 )
 
 include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ add_service_files(
         DIRECTORY srv
         FILES
         EmergencyStop.srv
+        GetVscSettings.srv
         KeyString.srv
         KeyValue.srv
-        GetVscSettings.srv
 )
 
 add_message_files(

--- a/include/hri_safe_remote_control_system/VehicleInterface.h
+++ b/include/hri_safe_remote_control_system/VehicleInterface.h
@@ -156,6 +156,45 @@ void vsc_send_user_feedback_string(VscInterfaceType* vscInterface, uint8_t key, 
  */
 void vsc_send_heartbeat(VscInterfaceType* vscInterface, uint8_t EStopStatus);
 
+/** vsc_scm_target_set()
+ * @brief This function sends a SCM Target Set Command to the VSC to prepare for a settings grab.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ * @param target_id The identifier for the target, 0 for local.
+ */
+void vsc_scm_target_set(VscInterfaceType* vscInterface, int target_id);
+
+/** vsc_scm_target_get()
+ * @brief This function sends a SCM Target Get Command to the VSC to prepare for a settings grab.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ */
+void vsc_scm_target_get(VscInterfaceType* vscInterface);
+
+/** vsc_setup_unlock()
+ * @brief This function unlocks Setup mode on the VSC to prepare for a settings grab.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ */
+void vsc_setup_unlock(VscInterfaceType* vscInterface);
+
+/** vsc_get_setting_int()
+ * @brief This function queries the VSC for a setting with the key, in integer format.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ * @param key The identifier for the setting to be queried.
+ */
+void vsc_get_setting_int(VscInterfaceType* vscInterface, uint8_t key);
+
+/** vsc_get_setting_string()
+ * @brief This function queries the VSC for a setting with the key, in string format.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ * @param key The identifier for the setting to be queried.
+ */
+void vsc_get_setting_string(VscInterfaceType* vscInterface, uint8_t key);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/hri_safe_remote_control_system/VehicleInterface.h
+++ b/include/hri_safe_remote_control_system/VehicleInterface.h
@@ -178,6 +178,14 @@ void vsc_scm_target_get(VscInterfaceType* vscInterface);
  */
 void vsc_setup_unlock(VscInterfaceType* vscInterface);
 
+/** vsc_get_setting()
+ * @brief This function queries the VSC for a setting with the key.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ * @param key The identifier for the setting to be queried.
+ */
+void vsc_get_setting(VscInterfaceType* vscInterface, uint8_t key);
+
 /** vsc_get_setting_int()
  * @brief This function queries the VSC for a setting with the key, in integer format.
  * 

--- a/include/hri_safe_remote_control_system/VehicleMessages.h
+++ b/include/hri_safe_remote_control_system/VehicleMessages.h
@@ -44,6 +44,9 @@ extern "C" {
 #define VSC_MIN_MESSAGE_LENGTH (VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD)
 
 #define VSC_USER_FEEDBACK_STRING_LENGTH 20
+#define VSC_SETTING_STRING_LENGTH 20
+#define VSC_SETTING_SERIAL_LENGTH 15
+#define VSC_SETTING_FIRMWARE_LENGTH 5
 
 /** VSC_STATES_TYPE
  * 	The enumerated values of VSC states.
@@ -69,8 +72,37 @@ enum VSC_MESSAGE_TYPE
   MSG_USER_HEARTBEAT = 0x21,
   MSG_VSC_REMOTE_STATUS = 0x22,
   MSG_USER_CONTROL_MSG_RATE = 0x23,
+  MSG_VSC_RX_STATUS = 0x25,
+  MSG_VSC_RX_STATUS_DIAG = 0x26,
   MSG_USER_FEEDBACK = 0x30,
-  MSG_USER_FEEDBACK_STRING = 0x31
+  MSG_USER_FEEDBACK_STRING = 0x31,
+  MSG_USER_VALUE_UNUSED = 0x33,
+  MSG_NSC_HEARTBEAT = 0x40,
+  MSG_TIMESTAMP = 0x50,
+  MSG_FILE_TRANSFER_ACK_NACK = 0x90,
+  MSG_FILE_TRANSFER_DATA = 0x94,
+  MSG_FILE_TRANSFER_CRC = 0x97,
+  MSG_FILE_TRANSFER_FILE_LENGTH = 0x99,
+  MSG_SETUP_KEY_INT_2 = 0xa2,
+  MSG_SETUP_KEY_REQ = 0xa3,           // Used for Tx to VSC only.
+  MSG_SETUP_KEY_STRING_2 = 0xa4,
+  MSG_SETUP_KEY_STRING_PART = 0xa8,
+  MSG_SETUP_KEY_LONG_STRING = 0xa9,
+  MSG_SETUP_KEY_INT_1 = 0xaa,
+  MSG_SETUP_KEY_INT_1_REQ = 0xab,       // Used for Tx to VSC only.
+  MSG_SETUP_KEY_STRING_1 = 0xac,
+  MSG_SETUP_KEY_STRING_1_REQ = 0xad,  // Used for Tx to VSC only.
+  MSG_SETUP_UNLOCK = 0xae,            // Used for Tx to VSC only.
+  MSG_EVENT_LOG_SEEK_FIRST_ACK = 0xb2,
+  MSG_EVENT_LOG_ENTRY = 0xb4,
+  MSG_EVENT_LOG_CLEAR_ALL_ACK = 0xb6,
+  MSG_EVENT_LOG_CURRENT = 0xb7,
+  MSG_PACKET_LOSS = 0xd3,
+  MSG_PACKET_LOSS_EOF = 0xd4,
+  MSG_NSC_RSSI = 0xd5,
+  MSG_SCM_TARGET_SET_ACK = 0xf7,
+  MSG_SCM_TARGET_GET = 0xf8,          // Used for Tx to VSC only.
+  MSG_SCM_TARGET_SET = 0xf9           // Used for Tx to VSC only.
 };
 
 /** VSC_USER_FEEDBACK_KEY_TYPE
@@ -96,6 +128,21 @@ enum VSC_USER_FEEDBACK_KEY_TYPE
   VSC_USER_DISPLAY_ROW_4 = 93,
   VSC_USER_DISPLAY_MODE = 99,
 };
+
+/** VSC_SETUP_KEY_TYPE
+ *  The enumerated values of the available setup parameter keys.
+ */
+enum VSC_SETUP_KEY_TYPE
+{
+  VSC_SETUP_KEY_SERIAL = 1,
+  VSC_SETUP_KEY_RADIO_POWER_LEVEL = 103,
+  VSC_SETUP_KEY_FIRMWARE = 111
+};
+
+/** VSC_SETUP_UNLOCK_CODE
+ *  The code to unlock setup mode on the VSC.
+ */
+const uint16_t VSC_SETUP_UNLOCK_CODE = 0xc0de;
 
 /** VscMsgData
  * 	The union for data that is sent and received to the VSC.  This contains
@@ -255,6 +302,39 @@ typedef struct
   uint8_t key;
   char value[VSC_USER_FEEDBACK_STRING_LENGTH];
 } UserFeedbackStringMsgType;
+
+/** SCMTargetSetMsgType
+ * 	The Structure for the packed target id that is used to transmit the SCM Target
+ *  Set command to the VSC.
+ */
+typedef struct
+{
+  uint32_t target_id;
+} SCMTargetSetMsgType;
+
+
+/** SCMTargetGetMsgType
+ * 	The Structure for the the SCM Target Get command transmitted to the VSC.
+ */
+typedef struct
+{
+} SCMTargetGetMsgType;
+
+/** SetupUnlockMsgType
+ * 	The Structure to unlock tthe setup state on the VSC with the unlock code packed.
+ */
+typedef struct
+{
+  uint16_t code;
+} SetupUnlockMsgType;
+
+/** GetSettingMsgType
+ * 	The Structure to query a setting from the VSC with the key packed.
+ */
+typedef struct
+{
+  uint8_t key;
+} GetSettingMsgType;
 
 /** MOTOR_INTENSITY_TYPE
  * 	The enumerated values of the motor control intensities

--- a/include/hri_safe_remote_control_system/VehicleMessages.h
+++ b/include/hri_safe_remote_control_system/VehicleMessages.h
@@ -142,7 +142,7 @@ enum VSC_SETUP_KEY_TYPE
 /** VSC_SETUP_UNLOCK_CODE
  *  The code to unlock setup mode on the VSC.
  */
-const uint16_t VSC_SETUP_UNLOCK_CODE = 0xc0de;
+const uint16_t VSC_SETUP_UNLOCK_CODE = 0xdec0;
 
 /** VscMsgData
  * 	The union for data that is sent and received to the VSC.  This contains

--- a/include/hri_safe_remote_control_system/VscProcess.h
+++ b/include/hri_safe_remote_control_system/VscProcess.h
@@ -28,6 +28,8 @@
 #include "hri_safe_remote_control_system/SrcDisplay.h"
 #include "hri_safe_remote_control_system/SrcHealth.h"
 
+#include "hri_safe_remote_control_system/GetVscSettings.h"
+
 /**
  * HRI_COMMON Includes
  */
@@ -64,6 +66,8 @@ public:
   bool KeyValue(KeyValue::Request& req, KeyValue::Response& res);
   bool KeyString(KeyString::Request& req, KeyString::Response& res);
 
+  bool vscSettingsSrv(GetVscSettings::Request &req, GetVscSettings::Response &res);
+
   void receivedVibration(const std_msgs::Bool msg);
   void receivedDisplayOnCommand(const hri_safe_remote_control_system::SrcDisplay& msg);
   void receivedDisplayOffCommand(const std_msgs::EmptyConstPtr& msg);
@@ -73,14 +77,24 @@ private:
   void readFromVehicle();
   int handleHeartbeatMsg(VscMsgType& recvMsg);
   int handleRemoteStatusMsg(VscMsgType& recvMsg);
+  int handleGetSettingInt(VscMsgType& recvMsg);
+  int handleGetSettingString(VscMsgType& recvMsg);
 
   // Local State
   uint32_t myEStopState;
   ErrorCounterType errorCounts;
   std::string serial_port_ = "/dev/ttyACM0";
   int serial_speed_ = 115200;
-  double bond_form_time_ = 30.0;
-  double bond_break_time_ = 30.0;
+
+  // Setting Grab Values
+  bool have_radio_power_level = false;
+  bool have_serial = false;
+  bool have_firmware = false;
+  bool srv_advertised = false;
+
+  int radio_power_level = -1;
+  std::string serial = "";
+  std::string firmware = "";
   
   // cached
   uint8_t latest_vsc_mode_{ 0 };

--- a/include/hri_safe_remote_control_system/VscProcess.h
+++ b/include/hri_safe_remote_control_system/VscProcess.h
@@ -90,7 +90,7 @@ private:
   bool have_radio_power_level = false;
   bool have_serial = false;
   bool have_firmware = false;
-  bool srv_advertised = false;
+  bool srv_ready = false;
 
   int radio_power_level = -1;
   std::string serial = "";

--- a/include/hri_safe_remote_control_system/VscProcess.h
+++ b/include/hri_safe_remote_control_system/VscProcess.h
@@ -79,6 +79,8 @@ private:
   ErrorCounterType errorCounts;
   std::string serial_port_ = "/dev/ttyACM0";
   int serial_speed_ = 115200;
+  double bond_form_time_ = 30.0;
+  double bond_break_time_ = 30.0;
   
   // cached
   uint8_t latest_vsc_mode_{ 0 };

--- a/include/hri_safe_remote_control_system/VscProcess.h
+++ b/include/hri_safe_remote_control_system/VscProcess.h
@@ -87,12 +87,12 @@ private:
   int serial_speed_ = 115200;
 
   // Setting Grab Values
-  bool have_radio_power_level = false;
+  bool have_radio_power_db = false;
   bool have_serial = false;
   bool have_firmware = false;
   bool srv_ready = false;
 
-  int radio_power_level = -1;
+  int radio_power_db = -1;
   std::string serial = "";
   std::string firmware = "";
   

--- a/include/hri_safe_remote_control_system/VscProcess.h
+++ b/include/hri_safe_remote_control_system/VscProcess.h
@@ -102,7 +102,7 @@ private:
   // ROS
   ros::NodeHandle rosNode;
   ros::Timer mainLoopTimer;
-  ros::ServiceServer estopServ, keyValueServ, keyStringServ;
+  ros::ServiceServer estopServ, keyValueServ, keyStringServ, vscSettingServ;
   ros::Publisher estopPub;
   ros::Publisher srcHealthPub;
   ros::Subscriber vibrateSrcSub;

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,5 @@
   <exec_depend>sensor_msgs</exec_depend>
   <depend>genmsg</depend>
   <depend>message_runtime</depend>
-  <depend>bond_core</depend>
 </package>
 

--- a/package.xml
+++ b/package.xml
@@ -22,5 +22,6 @@
   <exec_depend>sensor_msgs</exec_depend>
   <depend>genmsg</depend>
   <depend>message_runtime</depend>
+  <depend>bond_core</depend>
 </package>
 

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -128,12 +128,12 @@ int vsc_send_msg(VscInterfaceType* vscInterface, VscMsgType *sendMsg) {
 			(checksum >> 8) & 0xff;
 
 	/* Print Message for Diagnostic*/
-	printf("Sent Message: ");
-	for (int i = 0; i < sendMsg->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
-	{
-		printf("\\x%02x", sendMsg->msg.buffer[i]);
-	}
-	printf("\n");
+	// printf("Sent Message: ");
+	// for (int i = 0; i < sendMsg->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
+	// {
+	// 	printf("\\x%02x", sendMsg->msg.buffer[i]);
+	// }
+	// printf("\n");
 
 	/* Send message over VSC connection. */
 	retval = write_to_serial(vscInterface->fd, (void*) sendMsg->msg.buffer,
@@ -224,11 +224,11 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 									+ VSC_HEADER_OVERHEAD + 1], checksum & 0xff,
 							(checksum >> 8) & 0xff);
 
-					for (int i = 0; i < msgPtr->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
-					{
-						printf("\\x%02x", msgPtr->msg.buffer[i]);
-					}
-					printf("\n");
+					// for (int i = 0; i < msgPtr->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
+					// {
+					// 	printf("\\x%02x", msgPtr->msg.buffer[i]);
+					// }
+					// printf("\n");
 					
 					vscInterface->back += expectedLength;
 				}
@@ -436,11 +436,11 @@ void vsc_scm_target_set(VscInterfaceType* vscInterface, int target_id)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &scmTargetSetMsg) < 0) {
     // Error print commented out due to spam
-	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
 	else
 	{
-		printf("SCM TARGET SET %d\n", msgPtr->target_id);
+		// printf("SCM TARGET SET %d\n", msgPtr->target_id);
 	}
 }
 
@@ -461,11 +461,11 @@ void vsc_scm_target_get(VscInterfaceType* vscInterface)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &scmTargetGetMsg) < 0) {
     // Error print commented out due to spam
-	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
 	else
 	{
-		printf("SCM TARGET GET\n");
+		// printf("SCM TARGET GET\n");
 	}
 }
 
@@ -489,11 +489,11 @@ void vsc_setup_unlock(VscInterfaceType* vscInterface)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &setupUnlockMsg) < 0) {
     // Error print commented out due to spam
-	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
 	else
 	{
-		printf("SETUP UNLOCK %02x\n", msgPtr->code);
+		// printf("SETUP UNLOCK %02x\n", msgPtr->code);
 	}
 }
 
@@ -518,11 +518,11 @@ void vsc_get_setting(VscInterfaceType* vscInterface, uint8_t key)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
     // Error print commented out due to spam
-	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
 	else
 	{
-		printf("GET SETTING %d\n", msgPtr->key);
+		// printf("GET SETTING %d\n", msgPtr->key);
 	}
 }
 
@@ -547,11 +547,11 @@ void vsc_get_setting_int(VscInterfaceType* vscInterface, uint8_t key)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
     // Error print commented out due to spam
-	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
 	else
 	{
-		printf("GET SETTING INT %d\n", msgPtr->key);
+		// printf("GET SETTING INT %d\n", msgPtr->key);
 	}
 }
 

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -127,14 +127,6 @@ int vsc_send_msg(VscInterfaceType* vscInterface, VscMsgType *sendMsg) {
 	sendMsg->msg.buffer[sendMsg->msg.length + VSC_HEADER_OVERHEAD + 1] =
 			(checksum >> 8) & 0xff;
 
-	/* Print Message for Diagnostic*/
-	// printf("Sent Message: ");
-	// for (int i = 0; i < sendMsg->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
-	// {
-	// 	printf("\\x%02x", sendMsg->msg.buffer[i]);
-	// }
-	// printf("\n");
-
 	/* Send message over VSC connection. */
 	retval = write_to_serial(vscInterface->fd, (void*) sendMsg->msg.buffer,
 			sendMsg->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD);
@@ -207,7 +199,6 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 								== ((checksum >> 8) & 0xff))) {
 
 					/* Copy to output */
-					// printf("Received Message of type\\x%02x\n", msgPtr->msg.buffer[2]);
 					memcpy((void*) newMsg, (void*) msgPtr, expectedLength);
 
 					/* Update indices */
@@ -223,12 +214,6 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 							msgPtr->msg.buffer[msgPtr->msg.length
 									+ VSC_HEADER_OVERHEAD + 1], checksum & 0xff,
 							(checksum >> 8) & 0xff);
-
-					// for (int i = 0; i < msgPtr->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
-					// {
-					// 	printf("\\x%02x", msgPtr->msg.buffer[i]);
-					// }
-					// printf("\n");
 					
 					vscInterface->back += expectedLength;
 				}
@@ -438,10 +423,6 @@ void vsc_scm_target_set(VscInterfaceType* vscInterface, int target_id)
     // Error print commented out due to spam
 	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
-	else
-	{
-		// printf("SCM TARGET SET %d\n", msgPtr->target_id);
-	}
 }
 
 /** vsc_scm_target_get()
@@ -462,10 +443,6 @@ void vsc_scm_target_get(VscInterfaceType* vscInterface)
 	if (vsc_send_msg(vscInterface, &scmTargetGetMsg) < 0) {
     // Error print commented out due to spam
 	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
-	else
-	{
-		// printf("SCM TARGET GET\n");
 	}
 }
 
@@ -490,10 +467,6 @@ void vsc_setup_unlock(VscInterfaceType* vscInterface)
 	if (vsc_send_msg(vscInterface, &setupUnlockMsg) < 0) {
     // Error print commented out due to spam
 	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
-	else
-	{
-		// printf("SETUP UNLOCK %02x\n", msgPtr->code);
 	}
 }
 
@@ -520,10 +493,6 @@ void vsc_get_setting(VscInterfaceType* vscInterface, uint8_t key)
     // Error print commented out due to spam
 	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
-	else
-	{
-		// printf("GET SETTING %d\n", msgPtr->key);
-	}
 }
 
 /** vsc_get_setting_int()
@@ -549,10 +518,6 @@ void vsc_get_setting_int(VscInterfaceType* vscInterface, uint8_t key)
     // Error print commented out due to spam
 	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
-	else
-	{
-		// printf("GET SETTING INT %d\n", msgPtr->key);
-	}
 }
 
 /** vsc_get_setting_string()
@@ -576,11 +541,7 @@ void vsc_get_setting_string(VscInterfaceType* vscInterface, uint8_t key)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
     // Error print commented out due to spam
-	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
-	else
-	{
-		printf("GET SETTING STRING %d\n", msgPtr->key);
+	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
 	}
 }
 

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -399,6 +399,126 @@ void vsc_send_heartbeat(VscInterfaceType* vscInterface, uint8_t EStopStatus) {
 
 }
 
+/** vsc_scm_target_set()
+ * @brief This function sends a SCM Target Set Command to the VSC to prepare for a settings grab.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ * @param target_id The identifier for the target, 0 for local.
+ */
+void vsc_scm_target_set(VscInterfaceType* vscInterface, int target_id)
+{
+	VscMsgType scmTargetSetMsg;
+	SCMTargetSetMsgType *msgPtr = (SCMTargetSetMsgType*) scmTargetSetMsg.msg.data;
+
+	/* Fill Message */
+	scmTargetSetMsg.msg.msgType = MSG_SCM_TARGET_SET;
+	scmTargetSetMsg.msg.length = sizeof(SCMTargetSetMsgType);
+
+	/* Fill in the Target ID */
+	msgPtr->target_id = target_id;
+
+	/* Send Message */
+	if (vsc_send_msg(vscInterface, &scmTargetSetMsg) < 0) {
+    // Error print commented out due to spam
+	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+}
+
+/** vsc_scm_target_get()
+ * @brief This function sends a SCM Target Get Command to the VSC to prepare for a settings grab.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ */
+void vsc_scm_target_get(VscInterfaceType* vscInterface)
+{
+	VscMsgType scmTargetGetMsg;
+	SCMTargetGetMsgType *msgPtr = (SCMTargetGetMsgType*) scmTargetGetMsg.msg.data;
+
+	/* Fill Message */
+	scmTargetGetMsg.msg.msgType = MSG_SCM_TARGET_GET;
+	scmTargetGetMsg.msg.length = sizeof(SCMTargetGetMsgType);
+
+	/* Send Message */
+	if (vsc_send_msg(vscInterface, &scmTargetGetMsg) < 0) {
+    // Error print commented out due to spam
+	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+}
+
+/** vsc_setup_unlock()
+ * @brief This function unlocks Setup mode on the VSC to prepare for a settings grab.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ */
+void vsc_setup_unlock(VscInterfaceType* vscInterface)
+{
+	VscMsgType setupUnlockMsg;
+	SetupUnlockMsgType *msgPtr = (SetupUnlockMsgType*) setupUnlockMsg.msg.data;
+
+	/* Fill Message */
+	setupUnlockMsg.msg.msgType = MSG_SETUP_UNLOCK;
+	setupUnlockMsg.msg.length = sizeof(SetupUnlockMsgType);
+	
+	/* Fill in the Target ID */
+	msgPtr->code = VSC_SETUP_UNLOCK_CODE;
+
+	/* Send Message */
+	if (vsc_send_msg(vscInterface, &setupUnlockMsg) < 0) {
+    // Error print commented out due to spam
+	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+}
+
+/** vsc_get_setting_int()
+ * @brief This function queries the VSC for a setting with the key, in integer format.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ * @param key The identifier for the setting to be queried.
+ */
+void vsc_get_setting_int(VscInterfaceType* vscInterface, uint8_t key)
+{
+	VscMsgType getSettingMsg;
+	GetSettingMsgType *msgPtr = (GetSettingMsgType*) getSettingMsg.msg.data;
+
+	/* Fill Message */
+	getSettingMsg.msg.msgType = MSG_SETUP_KEY_INT_1_REQ;
+	getSettingMsg.msg.length = sizeof(SetupUnlockMsgType);
+	
+	/* Fill in the Target ID */
+	msgPtr->key = key;
+
+	/* Send Message */
+	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
+    // Error print commented out due to spam
+	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+}
+
+/** vsc_get_setting_string()
+ * @brief This function queries the VSC for a setting with the key, in string format.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ * @param key The identifier for the setting to be queried.
+ */
+void vsc_get_setting_string(VscInterfaceType* vscInterface, uint8_t key)
+{
+	VscMsgType getSettingMsg;
+	GetSettingMsgType *msgPtr = (GetSettingMsgType*) getSettingMsg.msg.data;
+
+	/* Fill Message */
+	getSettingMsg.msg.msgType = MSG_SETUP_KEY_STRING_1_REQ;
+	getSettingMsg.msg.length = sizeof(SetupUnlockMsgType);
+	
+	/* Fill in the Target ID */
+	msgPtr->key = key;
+
+	/* Send Message */
+	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
+    // Error print commented out due to spam
+	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+}
+
 /**
  * Get Serial Interface File Descriptor
  *

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -190,7 +190,7 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 			} else {
 
 				/* Calculate Fletchers Checksum verify */
-				ROS_INFO(msgPtr->msg.buffer)
+				ROS_INFO(msgPtr->msg.buffer);
 				uint16_t checksum = checksum_16((uint8_t*) msgPtr->msg.buffer,
 						msgPtr->msg.length + VSC_HEADER_OVERHEAD);
 				if ((msgPtr->msg.buffer[msgPtr->msg.length + VSC_HEADER_OVERHEAD]

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -199,6 +199,7 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 								== ((checksum >> 8) & 0xff))) {
 
 					/* Copy to output */
+					printf("Received Message of type\\x%02x\n", msgPtr->msg.buffer[2]);
 					memcpy((void*) newMsg, (void*) msgPtr, expectedLength);
 
 					/* Update indices */
@@ -214,13 +215,14 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 							msgPtr->msg.buffer[msgPtr->msg.length
 									+ VSC_HEADER_OVERHEAD + 1], checksum & 0xff,
 							(checksum >> 8) & 0xff);
-					vscInterface->back += expectedLength;
 
 					for (int i = 0; i < msgPtr->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
 					{
 						printf("\\x%02x", msgPtr->msg.buffer[i]);
 					}
 					printf("\n");
+					
+					vscInterface->back += expectedLength;
 				}
 			}
 		} else {

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -310,10 +310,7 @@ void vsc_send_control_msg_rate(VscInterfaceType* vscInterface, uint8_t msgTypeTo
   memcpy(feedbackMsg.msg.data, msgPtr, feedbackMsg.msg.length);
 
   /* Send Message */
-  if (vsc_send_msg(vscInterface, &feedbackMsg) < 0) {
-    // Error print commented out due to spam
-    fprintf(stderr, "vsc_send_control_msg_rate: Send Message Failure (Errno: %i)\n", errno);
-  }
+  vsc_send_msg(vscInterface, &feedbackMsg);
 }
 
 /**
@@ -338,10 +335,7 @@ void vsc_send_user_feedback(VscInterfaceType* vscInterface, uint8_t key, int32_t
 	msgPtr->value = value;
 
 	/* Send Message */
-	if (vsc_send_msg(vscInterface, &feedbackMsg) < 0) {
-    // Error print commented out due to spam
-	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
+	vsc_send_msg(vscInterface, &feedbackMsg);
 }
 
 /**
@@ -367,10 +361,7 @@ void vsc_send_user_feedback_string(VscInterfaceType* vscInterface, uint8_t key, 
 	strncpy(msgPtr->value, value, VSC_USER_FEEDBACK_STRING_LENGTH);
 
 	/* Send Message */
-	if (vsc_send_msg(vscInterface, &feedbackMsg) < 0) {
-		// Error print commented out due to spam
-	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
+	vsc_send_msg(vscInterface, &feedbackMsg);
 }
 
 /**
@@ -393,10 +384,7 @@ void vsc_send_heartbeat(VscInterfaceType* vscInterface, uint8_t EStopStatus) {
 	msgPtr->EStopStatus = EStopStatus;
 
 	/* Send Message */
-	if (vsc_send_msg(vscInterface, &heartbeatMsg) < 0) {
-    // Error print commented out due to spam
-	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
+	vsc_send_msg(vscInterface, &heartbeatMsg);
 
 }
 
@@ -419,10 +407,7 @@ void vsc_scm_target_set(VscInterfaceType* vscInterface, int target_id)
 	msgPtr->target_id = target_id;
 
 	/* Send Message */
-	if (vsc_send_msg(vscInterface, &scmTargetSetMsg) < 0) {
-    // Error print commented out due to spam
-	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
+	vsc_send_msg(vscInterface, &scmTargetSetMsg);
 }
 
 /** vsc_scm_target_get()
@@ -440,10 +425,7 @@ void vsc_scm_target_get(VscInterfaceType* vscInterface)
 	scmTargetGetMsg.msg.length = sizeof(SCMTargetGetMsgType);
 
 	/* Send Message */
-	if (vsc_send_msg(vscInterface, &scmTargetGetMsg) < 0) {
-    // Error print commented out due to spam
-	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
+	vsc_send_msg(vscInterface, &scmTargetGetMsg);
 }
 
 /** vsc_setup_unlock()
@@ -464,10 +446,7 @@ void vsc_setup_unlock(VscInterfaceType* vscInterface)
 	msgPtr->code = VSC_SETUP_UNLOCK_CODE;
 
 	/* Send Message */
-	if (vsc_send_msg(vscInterface, &setupUnlockMsg) < 0) {
-    // Error print commented out due to spam
-	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
+	vsc_send_msg(vscInterface, &setupUnlockMsg);
 }
 
 /** vsc_get_setting()
@@ -489,10 +468,7 @@ void vsc_get_setting(VscInterfaceType* vscInterface, uint8_t key)
 	msgPtr->key = key;
 
 	/* Send Message */
-	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
-    // Error print commented out due to spam
-	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
+	vsc_send_msg(vscInterface, &getSettingMsg);
 }
 
 /** vsc_get_setting_int()
@@ -514,10 +490,7 @@ void vsc_get_setting_int(VscInterfaceType* vscInterface, uint8_t key)
 	msgPtr->key = key;
 
 	/* Send Message */
-	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
-    // Error print commented out due to spam
-	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
+	vsc_send_msg(vscInterface, &getSettingMsg);
 }
 
 /** vsc_get_setting_string()
@@ -539,10 +512,7 @@ void vsc_get_setting_string(VscInterfaceType* vscInterface, uint8_t key)
 	msgPtr->key = key;
 
 	/* Send Message */
-	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
-    // Error print commented out due to spam
-	  // fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
-	}
+	vsc_send_msg(vscInterface, &getSettingMsg);
 }
 
 /**

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -29,6 +29,8 @@
 #include "hri_safe_remote_control_system/VehicleInterface.h"
 #include "hri_safe_remote_control_system/SerialInterface.h"
 
+#include "ros/ros.h"
+
 /**
  * Calculate the Fletcher 16 Checksum
  *

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -197,9 +197,15 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 						&& (msgPtr->msg.buffer[msgPtr->msg.length
 								+ VSC_HEADER_OVERHEAD + 1]
 								== ((checksum >> 8) & 0xff))) {
-									
-					retval = 1;
 
+					/* Copy to output */
+					memcpy((void*) newMsg, (void*) msgPtr, expectedLength);
+
+					/* Update indices */
+					vscInterface->back += expectedLength;
+
+					done = true;
+					retval = 1;
 				} else {
 					fprintf(stderr,
 							"VscInterface: Invalid checksum 0x%02x 0x%02x received when expecting 0x%02x 0x%02x\n",
@@ -208,17 +214,14 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 							msgPtr->msg.buffer[msgPtr->msg.length
 									+ VSC_HEADER_OVERHEAD + 1], checksum & 0xff,
 							(checksum >> 8) & 0xff);
-							
-					retval = -2;
-				}
-				
-				/* Copy to output */
-				memcpy((void*) newMsg, (void*) msgPtr, expectedLength);
+					vscInterface->back += expectedLength;
 
-				/* Update indices */
-				vscInterface->back += expectedLength;
-				
-				done = true;
+					for (int i = 0; i < msgPtr->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
+					{
+						printf("\\x%02x", msgPtr->msg.buffer[i]);
+					}
+					printf("\n");
+				}
 			}
 		} else {
 			/* Search for start of message. */

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -208,6 +208,8 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 							msgPtr->msg.buffer[msgPtr->msg.length
 									+ VSC_HEADER_OVERHEAD + 1], checksum & 0xff,
 							(checksum >> 8) & 0xff);
+							
+					retval = -2;
 				}
 				
 				/* Copy to output */

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -190,6 +190,7 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 			} else {
 
 				/* Calculate Fletchers Checksum verify */
+				ROS_INFO(msgPtr->msg.buffer)
 				uint16_t checksum = checksum_16((uint8_t*) msgPtr->msg.buffer,
 						msgPtr->msg.length + VSC_HEADER_OVERHEAD);
 				if ((msgPtr->msg.buffer[msgPtr->msg.length + VSC_HEADER_OVERHEAD]

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -199,7 +199,7 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 								== ((checksum >> 8) & 0xff))) {
 
 					/* Copy to output */
-					printf("Received Message of type\\x%02x\n", msgPtr->msg.buffer[2]);
+					// printf("Received Message of type\\x%02x\n", msgPtr->msg.buffer[2]);
 					memcpy((void*) newMsg, (void*) msgPtr, expectedLength);
 
 					/* Update indices */
@@ -428,7 +428,11 @@ void vsc_scm_target_set(VscInterfaceType* vscInterface, int target_id)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &scmTargetSetMsg) < 0) {
     // Error print commented out due to spam
-	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+	else
+	{
+		printf("SCM TARGET SET %d\n", msgPtr->target_id);
 	}
 }
 
@@ -449,7 +453,11 @@ void vsc_scm_target_get(VscInterfaceType* vscInterface)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &scmTargetGetMsg) < 0) {
     // Error print commented out due to spam
-	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+	else
+	{
+		printf("SCM TARGET GET\n");
 	}
 }
 
@@ -473,7 +481,11 @@ void vsc_setup_unlock(VscInterfaceType* vscInterface)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &setupUnlockMsg) < 0) {
     // Error print commented out due to spam
-	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+	else
+	{
+		printf("SETUP UNLOCK %02x\n", msgPtr->code);
 	}
 }
 
@@ -498,7 +510,11 @@ void vsc_get_setting_int(VscInterfaceType* vscInterface, uint8_t key)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
     // Error print commented out due to spam
-	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+	else
+	{
+		printf("GET SETTING INT %d\n", msgPtr->key);
 	}
 }
 
@@ -523,7 +539,11 @@ void vsc_get_setting_string(VscInterfaceType* vscInterface, uint8_t key)
 	/* Send Message */
 	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
     // Error print commented out due to spam
-	  //fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+	else
+	{
+		printf("GET SETTING STRING %d\n", msgPtr->key);
 	}
 }
 

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -489,6 +489,35 @@ void vsc_setup_unlock(VscInterfaceType* vscInterface)
 	}
 }
 
+/** vsc_get_setting()
+ * @brief This function queries the VSC for a setting with the key.
+ * 
+ * @param vscInterface VSC Interface Structure.
+ * @param key The identifier for the setting to be queried.
+ */
+void vsc_get_setting(VscInterfaceType* vscInterface, uint8_t key)
+{
+	VscMsgType getSettingMsg;
+	GetSettingMsgType *msgPtr = (GetSettingMsgType*) getSettingMsg.msg.data;
+
+	/* Fill Message */
+	getSettingMsg.msg.msgType = MSG_SETUP_KEY_REQ;
+	getSettingMsg.msg.length = sizeof(SetupUnlockMsgType);
+	
+	/* Fill in the Target ID */
+	msgPtr->key = key;
+
+	/* Send Message */
+	if (vsc_send_msg(vscInterface, &getSettingMsg) < 0) {
+    // Error print commented out due to spam
+	  fprintf(stderr, "vsc_example: Send Message Failure (Errno: %i)\n", errno);
+	}
+	else
+	{
+		printf("GET SETTING %d\n", msgPtr->key);
+	}
+}
+
 /** vsc_get_setting_int()
  * @brief This function queries the VSC for a setting with the key, in integer format.
  * 

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -127,6 +127,14 @@ int vsc_send_msg(VscInterfaceType* vscInterface, VscMsgType *sendMsg) {
 	sendMsg->msg.buffer[sendMsg->msg.length + VSC_HEADER_OVERHEAD + 1] =
 			(checksum >> 8) & 0xff;
 
+	/* Print Message for Diagnostic*/
+	printf("Sent Message: ");
+	for (int i = 0; i < sendMsg->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
+	{
+		printf("\\x%02x", sendMsg->msg.buffer[i]);
+	}
+	printf("\n");
+
 	/* Send message over VSC connection. */
 	retval = write_to_serial(vscInterface->fd, (void*) sendMsg->msg.buffer,
 			sendMsg->msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD);

--- a/src/VehicleInterface.c
+++ b/src/VehicleInterface.c
@@ -29,8 +29,6 @@
 #include "hri_safe_remote_control_system/VehicleInterface.h"
 #include "hri_safe_remote_control_system/SerialInterface.h"
 
-#include "ros/ros.h"
-
 /**
  * Calculate the Fletcher 16 Checksum
  *
@@ -192,7 +190,6 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 			} else {
 
 				/* Calculate Fletchers Checksum verify */
-				ROS_INFO(msgPtr->msg.buffer);
 				uint16_t checksum = checksum_16((uint8_t*) msgPtr->msg.buffer,
 						msgPtr->msg.length + VSC_HEADER_OVERHEAD);
 				if ((msgPtr->msg.buffer[msgPtr->msg.length + VSC_HEADER_OVERHEAD]
@@ -200,15 +197,9 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 						&& (msgPtr->msg.buffer[msgPtr->msg.length
 								+ VSC_HEADER_OVERHEAD + 1]
 								== ((checksum >> 8) & 0xff))) {
-
-					/* Copy to output */
-					memcpy((void*) newMsg, (void*) msgPtr, expectedLength);
-
-					/* Update indices */
-					vscInterface->back += expectedLength;
-
-					done = true;
+									
 					retval = 1;
+
 				} else {
 					fprintf(stderr,
 							"VscInterface: Invalid checksum 0x%02x 0x%02x received when expecting 0x%02x 0x%02x\n",
@@ -217,8 +208,15 @@ int vsc_read_next_msg(VscInterfaceType* vscInterface, VscMsgType *newMsg) {
 							msgPtr->msg.buffer[msgPtr->msg.length
 									+ VSC_HEADER_OVERHEAD + 1], checksum & 0xff,
 							(checksum >> 8) & 0xff);
-					vscInterface->back += expectedLength;
 				}
+				
+				/* Copy to output */
+				memcpy((void*) newMsg, (void*) msgPtr, expectedLength);
+
+				/* Update indices */
+				vscInterface->back += expectedLength;
+				
+				done = true;
 			}
 		} else {
 			/* Search for start of message. */

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -111,6 +111,8 @@ VscProcess::VscProcess() : myEStopState(0)
   keyValueServ = rosNode.advertiseService("safety/service/key_value", &VscProcess::KeyValue, this);
   keyStringServ = rosNode.advertiseService("safety/service/key_string", &VscProcess::KeyString, this);
 
+  ros::ServiceServer service = rosNode.advertiseService("/vsc/settings", &VscProcess::vscSettingsSrv, this);
+
   // Publish Emergency Stop Status
   estopPub = rosNode.advertise<std_msgs::UInt32>("safety/emergency_stop", 10);
   
@@ -235,6 +237,7 @@ bool VscProcess::KeyString(KeyString::Request& req, KeyString::Response& res)
 
 bool VscProcess::vscSettingsSrv(GetVscSettings::Request  &req, GetVscSettings::Response &res)
 {
+  res.srv_ready = srv_ready;
   res.serial_number = serial;
   res.firmware_version = firmware;
   res.radio_power_level = radio_power_level;
@@ -250,12 +253,10 @@ void VscProcess::processOneLoop(const ros::TimerEvent&)
   // Check for new data from vehicle in every state
   readFromVehicle();
 
-  if (have_firmware && have_radio_power_level && have_firmware && !srv_advertised)
+  if (have_firmware && have_radio_power_level && have_firmware && !srv_ready)
   {
-    ROS_INFO("Settings Grabbed from VSC, advertising service..");
-    ros::ServiceServer service = rosNode.advertiseService("/vsc/settings", &VscProcess::vscSettingsSrv, this);
-    ros::spinOnce();
-    srv_advertised = true;
+    srv_ready = true;
+    ROS_INFO("Settings Grabbed from VSC, service is ready..");
   }
 }
 

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -335,9 +335,15 @@ int VscProcess::handleRemoteStatusMsg(VscMsgType& recvMsg)
 int VscProcess::handleGetSettingInt(VscMsgType& recvMsg)
 {
   int retVal = 0;
-
   if (recvMsg.msg.length == (sizeof(uint8_t) + sizeof(int32_t)))
   {
+    std::stringstream ss;
+    for (size_t i = 0; i < recvMsg.msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
+    {
+        ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
+    }
+    ROS_INFO("Received Raw Message: %s", ss.str().c_str());
+
     if (recvMsg.msg.data[0] == VSC_SETUP_KEY_RADIO_POWER_LEVEL)
     {
       radio_power_level = recvMsg.msg.data[1] + 
@@ -366,6 +372,13 @@ int VscProcess::handleGetSettingString(VscMsgType& recvMsg)
 
   if (recvMsg.msg.length == (sizeof(uint8_t) + VSC_SETTING_STRING_LENGTH))
   {
+    std::stringstream ss;
+    for (size_t i = 0; i < recvMsg.msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
+    {
+        ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
+    }
+    ROS_INFO("Received Raw Message: %s", ss.str().c_str());
+
     if (recvMsg.msg.data[0] == VSC_SETUP_KEY_SERIAL)
     {
       serial = std::string(recvMsg.msg.data[1], VSC_SETTING_SERIAL_LENGTH);
@@ -425,6 +438,9 @@ void VscProcess::readFromVehicle()
         break;
       case MSG_USER_FEEDBACK:
         //			handleFeedbackMsg(&recvMsg);
+        break;
+      case MSG_SETUP_KEY_INT_2:
+        //			handleGetSettingInt2(&recvMsg);
         break;
       case MSG_SETUP_KEY_INT_1:
         ROS_INFO("Received MSG_SETUP_KEY_INT_1");

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -63,7 +63,7 @@ VscProcess::VscProcess() : myEStopState(0)
     ROS_INFO("Bond Break Time updated to:  %f", bond_break_time_);
   }
   bond.start();
-  if (!bond.waitUntilFormed(ros::Duration(bond_wait_time_)))
+  if (!bond.waitUntilFormed(ros::Duration(bond_form_time_)))
   {
     ROS_ERROR("Bond could not be formed to the VSC Settings Grabber!");
   }

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -111,7 +111,7 @@ VscProcess::VscProcess() : myEStopState(0)
   keyValueServ = rosNode.advertiseService("safety/service/key_value", &VscProcess::KeyValue, this);
   keyStringServ = rosNode.advertiseService("safety/service/key_string", &VscProcess::KeyString, this);
 
-  ros::ServiceServer service = rosNode.advertiseService("vsc/settings", &VscProcess::vscSettingsSrv, this);
+  vscSettingServ = rosNode.advertiseService("vsc/settings", &VscProcess::vscSettingsSrv, this);
 
   // Publish Emergency Stop Status
   estopPub = rosNode.advertise<std_msgs::UInt32>("safety/emergency_stop", 10);

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -383,7 +383,7 @@ void VscProcess::readFromVehicle()
     std::stringstream ss;
     for (int i = 0; i < recvMsg.msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
     {
-      ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
+      ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
     }
 
     ROS_INFO("Received Message: %s", ss.str().c_str());

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -342,7 +342,6 @@ int VscProcess::handleGetSettingInt(VscMsgType& recvMsg)
     {
         ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
     }
-    ROS_INFO("Received Raw Message: %s", ss.str().c_str());
 
     if (recvMsg.msg.data[0] == VSC_SETUP_KEY_RADIO_POWER_LEVEL)
     {
@@ -351,7 +350,6 @@ int VscProcess::handleGetSettingInt(VscMsgType& recvMsg)
       {
           ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.data[i]);
       }
-      ROS_INFO("Raw Data: %s", ss.str().c_str());
       
       radio_power_level = recvMsg.msg.data[1] | (recvMsg.msg.data[2] << 8) | (recvMsg.msg.data[3] << 16) | (recvMsg.msg.data[4] << 24);
 
@@ -381,14 +379,12 @@ int VscProcess::handleGetSettingString(VscMsgType& recvMsg)
     {
         ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
     }
-    ROS_INFO("Received Raw Message: %s", ss.str().c_str());
 
     if (recvMsg.msg.data[0] == VSC_SETUP_KEY_SERIAL)
     {
       serial.assign(reinterpret_cast<const char*>(recvMsg.msg.data+1), VSC_SETTING_SERIAL_LENGTH);
 
       have_serial = true;
-      ROS_INFO("Acquired VSC Serial Number");
     }
     else if (recvMsg.msg.data[0] == VSC_SETUP_KEY_FIRMWARE)
     {
@@ -447,14 +443,12 @@ void VscProcess::readFromVehicle()
         //			handleGetSettingInt2(&recvMsg);
         break;
       case MSG_SETUP_KEY_INT_1:
-        ROS_INFO("Received MSG_SETUP_KEY_INT_1");
         if(handleGetSettingInt(recvMsg) == 0)
         {
           lastDataRx = ros::Time::now();
         }
         break;
       case MSG_SETUP_KEY_STRING_1:
-        ROS_INFO("Received MSG_SETUP_KEY_STRING_1");
         if(handleGetSettingString(recvMsg) == 0)
         {
           lastDataRx = ros::Time::now();

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -111,7 +111,7 @@ VscProcess::VscProcess() : myEStopState(0)
   keyValueServ = rosNode.advertiseService("safety/service/key_value", &VscProcess::KeyValue, this);
   keyStringServ = rosNode.advertiseService("safety/service/key_string", &VscProcess::KeyString, this);
 
-  ros::ServiceServer service = rosNode.advertiseService("/vsc/settings", &VscProcess::vscSettingsSrv, this);
+  ros::ServiceServer service = rosNode.advertiseService("vsc/settings", &VscProcess::vscSettingsSrv, this);
 
   // Publish Emergency Stop Status
   estopPub = rosNode.advertise<std_msgs::UInt32>("safety/emergency_stop", 10);

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -56,11 +56,11 @@ VscProcess::VscProcess() : myEStopState(0)
   bond::Bond bond("/vsc_bond", "FortVSCSettingGrab");
   if (nh.getParam("bond_form_time", bond_form_time_))
   {
-    ROS_INFO("Bond Form Time updated to:  %i", bond_form_time_);
+    ROS_INFO("Bond Form Time updated to:  %d", bond_form_time_);
   }
   if (nh.getParam("bond_break_time", bond_break_time_))
   {
-    ROS_INFO("Bond Break Time updated to:  %i", bond_break_time_);
+    ROS_INFO("Bond Break Time updated to:  %d", bond_break_time_);
   }
   bond.start();
   if (!bond.waitUntilFormed(ros::Duration(bond_wait_time_)))

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -80,21 +80,21 @@ VscProcess::VscProcess() : myEStopState(0)
   vsc_scm_target_set(vscInterface, 0);
   vsc_scm_target_get(vscInterface);
 
-  ros::Duration(0.1).sleep();
+  // ros::Duration(0.1).sleep();
 
   vsc_setup_unlock(vscInterface);
   vsc_get_setting(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
   vsc_get_setting(vscInterface, VSC_SETUP_KEY_SERIAL);
   vsc_get_setting(vscInterface, VSC_SETUP_KEY_FIRMWARE);
   
-  ros::Duration(0.1).sleep();
+  // ros::Duration(0.1).sleep();
 
   vsc_setup_unlock(vscInterface);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_SERIAL);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_FIRMWARE);
   
-  ros::Duration(0.1).sleep();
+  // ros::Duration(0.1).sleep();
 
   vsc_setup_unlock(vscInterface);
   vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -253,7 +253,7 @@ void VscProcess::processOneLoop(const ros::TimerEvent&)
   // Check for new data from vehicle in every state
   readFromVehicle();
 
-  if (have_firmware && have_radio_power_level && have_firmware && !srv_ready)
+  if (have_serial && have_radio_power_level && have_firmware && !srv_ready)
   {
     srv_ready = true;
     ROS_INFO("Settings Grabbed from VSC, service is ready..");

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -62,8 +62,17 @@ VscProcess::VscProcess() : myEStopState(0)
   {
     ROS_INFO("Bond Break Time updated to:  %f", bond_break_time_);
   }
+
   bond.start();
-  if (!bond.waitUntilFormed(ros::Duration(bond_form_time_)))
+  ros::spinOnce();
+  int bond_form_ticker = 0;
+  while (!bond.waitUntilFormed(ros::Duration(0.1)) and bond_form_ticker < bond_form_time_)
+  {
+    bond_form_ticker += 0.1;
+    ros::spinOnce();
+  }
+
+  if (bond_form_ticker >= bond_form_time_)
   {
     ROS_ERROR("Bond could not be formed to the VSC Settings Grabber!");
   }

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -379,7 +379,15 @@ void VscProcess::readFromVehicle()
   /* Read all messages */
   while (vsc_read_next_msg(vscInterface, &recvMsg) > 0)
   {
-    ROS_INFO("Received Message: %s", recvMsg.msg.buffer);
+
+    std::stringstream ss;
+    for (int i = 0; i < recvMsg.msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
+    {
+      ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
+    }
+
+    ROS_INFO("Received Message: %s", ss.str().c_str());
+
     /* Read next Vsc Message */
     switch (recvMsg.msg.msgType)
     {

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -379,6 +379,7 @@ void VscProcess::readFromVehicle()
   /* Read all messages */
   while (vsc_read_next_msg(vscInterface, &recvMsg) > 0)
   {
+    ROS_INFO("Received Message: %s", recvMsg.msg.buffer);
     /* Read next Vsc Message */
     switch (recvMsg.msg.msgType)
     {

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -81,17 +81,17 @@ VscProcess::VscProcess() : myEStopState(0)
   vsc_scm_target_get(vscInterface);
 
   vsc_setup_unlock(vscInterface);
-  vsc_get_setting(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
+  vsc_get_setting(vscInterface, VSC_SETUP_KEY_radio_power_db);
   vsc_get_setting(vscInterface, VSC_SETUP_KEY_SERIAL);
   vsc_get_setting(vscInterface, VSC_SETUP_KEY_FIRMWARE);
 
   vsc_setup_unlock(vscInterface);
-  vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
+  vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_radio_power_db);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_SERIAL);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_FIRMWARE);
 
   vsc_setup_unlock(vscInterface);
-  vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
+  vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_radio_power_db);
   vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_SERIAL);
   vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_FIRMWARE);
 
@@ -234,7 +234,7 @@ bool VscProcess::vscSettingsSrv(GetVscSettings::Request  &req, GetVscSettings::R
   res.srv_ready = srv_ready;
   res.serial_number = serial;
   res.firmware_version = firmware;
-  res.radio_power_level = radio_power_level;
+  res.radio_power_db = radio_power_db;
 
   return true;
 }
@@ -247,7 +247,7 @@ void VscProcess::processOneLoop(const ros::TimerEvent&)
   // Check for new data from vehicle in every state
   readFromVehicle();
 
-  if (have_serial && have_radio_power_level && have_firmware && !srv_ready)
+  if (have_serial && have_radio_power_db && have_firmware && !srv_ready)
   {
     srv_ready = true;
     ROS_INFO("Settings Grabbed from VSC, service is ready..");
@@ -337,7 +337,7 @@ int VscProcess::handleGetSettingInt(VscMsgType& recvMsg)
         ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
     }
 
-    if (recvMsg.msg.data[0] == VSC_SETUP_KEY_RADIO_POWER_LEVEL)
+    if (recvMsg.msg.data[0] == VSC_SETUP_KEY_radio_power_db)
     {
       std::stringstream ss;
       for (size_t i = 0; i < recvMsg.msg.length; i++)
@@ -345,9 +345,9 @@ int VscProcess::handleGetSettingInt(VscMsgType& recvMsg)
           ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.data[i]);
       }
       
-      radio_power_level = recvMsg.msg.data[1] | (recvMsg.msg.data[2] << 8) | (recvMsg.msg.data[3] << 16) | (recvMsg.msg.data[4] << 24);
+      radio_power_db = recvMsg.msg.data[1] | (recvMsg.msg.data[2] << 8) | (recvMsg.msg.data[3] << 16) | (recvMsg.msg.data[4] << 24);
 
-      have_radio_power_level = true;
+      have_radio_power_db = true;
       ROS_INFO("Acquired VSC Radio Power Level");
     }
   }

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -56,11 +56,11 @@ VscProcess::VscProcess() : myEStopState(0)
   bond::Bond bond("/vsc_bond", "FortVSCSettingGrab");
   if (nh.getParam("bond_form_time", bond_form_time_))
   {
-    ROS_INFO("Bond Form Time updated to:  %d", bond_form_time_);
+    ROS_INFO("Bond Form Time updated to:  %f", bond_form_time_);
   }
   if (nh.getParam("bond_break_time", bond_break_time_))
   {
-    ROS_INFO("Bond Break Time updated to:  %d", bond_break_time_);
+    ROS_INFO("Bond Break Time updated to:  %f", bond_break_time_);
   }
   bond.start();
   if (!bond.waitUntilFormed(ros::Duration(bond_wait_time_)))

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -78,6 +78,8 @@ VscProcess::VscProcess() : myEStopState(0)
   }
   else
   {
+    ROS_INFO("Bond has been formed to the VSC Settings Grabber. Waiting for bond break...");
+    
     int bond_break_ticker = 0;
     while (!bond.waitUntilBroken(ros::Duration(0.1)) and bond_break_ticker < bond_break_time_)
     {
@@ -89,7 +91,10 @@ VscProcess::VscProcess() : myEStopState(0)
     {
       ROS_ERROR("Bond was not broken in time to the VSC Settings Grabber!");
     }
-    ROS_INFO("VSC Settings Grabber has broken the bond\n");
+    else
+    {
+      ROS_INFO("The bond has been broken to VSC Settings Grabber. Continuing node execution...\n");
+    }
   }
 
   /* Open VSC Interface */

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -18,6 +18,7 @@
 #include "ros/ros.h"
 #include "sensor_msgs/Joy.h"
 #include "std_msgs/UInt32.h"
+#include <bondcpp/bond.h>
 
 /**
  * System Includes
@@ -49,6 +50,19 @@ VscProcess::VscProcess() : myEStopState(0)
   if (nh.getParam("serial_speed", serial_speed_))
   {
     ROS_INFO("Serial Port Speed updated to:  %i", serial_speed_);
+  }
+
+  /* Bond with VSC Setting Grab Script and Wait for Completion*/
+  bond::Bond bond("/vsc_bond", "FortVSCSettingGrab");
+  bond.start();
+  if (!bond.waitUntilFormed(ros::Duration(5.0)))
+  {
+    ROS_ERROR("Bond could not be formed to the VSC Settings Grabber!");
+  }
+  else
+  {
+    bond.waitUntilBroken(ros::Duration(30.0));
+    ROS_INFO("VSC Settings Grabber has broken the bond\n");
   }
 
   /* Open VSC Interface */

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -431,14 +431,17 @@ void VscProcess::readFromVehicle()
 
       readRetVal = vsc_read_next_msg(vscInterface, &recvMsg) > 0;
     }
-    if (readRetVal == -2)
-    std::stringstream ss;
-    for (int i = 0; i < recvMsg.msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
-    {
-      ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
-    }
 
-    ROS_INFO("Received Message: %s", ss.str().c_str());
+    if (readRetVal == -2)
+    {
+      std::stringstream ss;
+      for (int i = 0; i < recvMsg.msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
+      {
+        ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
+      }
+
+      ROS_INFO("Received Message: %s", ss.str().c_str());
+    }
   }
 
   // Log warning when no data is received

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -53,7 +53,7 @@ VscProcess::VscProcess() : myEStopState(0)
   }
 
   /* Bond with VSC Setting Grab Script and Wait for Completion*/
-  bond::Bond bond("/vsc_bond", "FortVSCSettingGrab");
+  bond::Bond bond("/vsc/bond", "FortVSCSettingGrab");
   if (nh.getParam("bond_form_time", bond_form_time_))
   {
     ROS_INFO("Bond Form Time updated to:  %f", bond_form_time_);

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -254,6 +254,7 @@ void VscProcess::processOneLoop(const ros::TimerEvent&)
   {
     ROS_INFO("Settings Grabbed from VSC, advertising service..");
     ros::ServiceServer service = rosNode.advertiseService("/vsc/settings", &VscProcess::vscSettingsSrv, this);
+    ros::spinOnce();
     srv_advertised = true;
   }
 }

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -80,21 +80,15 @@ VscProcess::VscProcess() : myEStopState(0)
   vsc_scm_target_set(vscInterface, 0);
   vsc_scm_target_get(vscInterface);
 
-  // ros::Duration(0.1).sleep();
-
   vsc_setup_unlock(vscInterface);
   vsc_get_setting(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
   vsc_get_setting(vscInterface, VSC_SETUP_KEY_SERIAL);
   vsc_get_setting(vscInterface, VSC_SETUP_KEY_FIRMWARE);
-  
-  // ros::Duration(0.1).sleep();
 
   vsc_setup_unlock(vscInterface);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_SERIAL);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_FIRMWARE);
-  
-  // ros::Duration(0.1).sleep();
 
   vsc_setup_unlock(vscInterface);
   vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -383,8 +383,7 @@ void VscProcess::readFromVehicle()
   VscMsgType recvMsg;
 
   /* Read all messages */
-  int readRetVal = vsc_read_next_msg(vscInterface, &recvMsg) > 0;
-  while (readRetVal > 0)
+  while (vsc_read_next_msg(vscInterface, &recvMsg) > 0)
   {
     /* Read next Vsc Message */
     switch (recvMsg.msg.msgType)
@@ -414,33 +413,23 @@ void VscProcess::readFromVehicle()
         //			handleFeedbackMsg(&recvMsg);
         break;
       case MSG_SETUP_KEY_INT_1:
-        	if(handleGetSettingInt(recvMsg) == 0)
-          {
-            lastDataRx = ros::Time::now();
-          }
+        ROS_INFO("Received MSG_SETUP_KEY_INT_1");
+        if(handleGetSettingInt(recvMsg) == 0)
+        {
+          lastDataRx = ros::Time::now();
+        }
         break;
       case MSG_SETUP_KEY_STRING_1:
-        	if(handleGetSettingString(recvMsg) == 0)
-          {
-            lastDataRx = ros::Time::now();
-          }
+        ROS_INFO("Received MSG_SETUP_KEY_STRING_1");
+        if(handleGetSettingString(recvMsg) == 0)
+        {
+          lastDataRx = ros::Time::now();
+        }
         break;
       default:
+        ROS_WARN("Received Invalid Message!");
         errorCounts.invalidRxMsgCount++;
         break;
-
-      readRetVal = vsc_read_next_msg(vscInterface, &recvMsg) > 0;
-    }
-
-    if (readRetVal == -2)
-    {
-      std::stringstream ss;
-      for (int i = 0; i < recvMsg.msg.length + VSC_HEADER_OVERHEAD + VSC_FOOTER_OVERHEAD; i++)
-      {
-        ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
-      }
-
-      ROS_INFO("Received Message: %s", ss.str().c_str());
     }
   }
 

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -78,7 +78,17 @@ VscProcess::VscProcess() : myEStopState(0)
   }
   else
   {
-    bond.waitUntilBroken(ros::Duration(bond_break_time_));
+    int bond_break_ticker = 0;
+    while (!bond.waitUntilBroken(ros::Duration(0.1)) and bond_break_ticker < bond_break_time_)
+    {
+      bond_break_ticker += 0.1;
+      ros::spinOnce();
+    }
+
+    if (bond_break_ticker >= bond_break_time_)
+    {
+      ROS_ERROR("Bond was not broken in time to the VSC Settings Grabber!");
+    }
     ROS_INFO("VSC Settings Grabber has broken the bond\n");
   }
 

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -78,17 +78,28 @@ VscProcess::VscProcess() : myEStopState(0)
   }
 
   vsc_scm_target_set(vscInterface, 0);
-  ros::Duration(0.1).sleep();
   vsc_scm_target_get(vscInterface);
+
   ros::Duration(0.1).sleep();
+
   vsc_setup_unlock(vscInterface);
+  vsc_get_setting(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
+  vsc_get_setting(vscInterface, VSC_SETUP_KEY_SERIAL);
+  vsc_get_setting(vscInterface, VSC_SETUP_KEY_FIRMWARE);
+  
   ros::Duration(0.1).sleep();
+
+  vsc_setup_unlock(vscInterface);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
+  vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_SERIAL);
+  vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_FIRMWARE);
+  
   ros::Duration(0.1).sleep();
+
+  vsc_setup_unlock(vscInterface);
+  vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
   vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_SERIAL);
-  ros::Duration(0.1).sleep();
   vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_FIRMWARE);
-  ros::Duration(0.1).sleep();
 
   // Create Message Handlers
   joystickHandler = new JoystickHandler();
@@ -241,6 +252,7 @@ void VscProcess::processOneLoop(const ros::TimerEvent&)
 
   if (have_firmware && have_radio_power_level && have_firmware && !srv_advertised)
   {
+    ROS_INFO("Settings Grabbed from VSC, advertising service..");
     ros::ServiceServer service = rosNode.advertiseService("/vsc/settings", &VscProcess::vscSettingsSrv, this);
     srv_advertised = true;
   }
@@ -427,7 +439,7 @@ void VscProcess::readFromVehicle()
         }
         break;
       default:
-        ROS_WARN("Received Invalid Message!");
+        ROS_WARN("Received Invalid Message of type: %02x", recvMsg.msg.msgType);
         errorCounts.invalidRxMsgCount++;
         break;
     }

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -54,14 +54,22 @@ VscProcess::VscProcess() : myEStopState(0)
 
   /* Bond with VSC Setting Grab Script and Wait for Completion*/
   bond::Bond bond("/vsc_bond", "FortVSCSettingGrab");
+  if (nh.getParam("bond_form_time", bond_form_time_))
+  {
+    ROS_INFO("Bond Form Time updated to:  %i", bond_form_time_);
+  }
+  if (nh.getParam("bond_break_time", bond_break_time_))
+  {
+    ROS_INFO("Bond Break Time updated to:  %i", bond_break_time_);
+  }
   bond.start();
-  if (!bond.waitUntilFormed(ros::Duration(5.0)))
+  if (!bond.waitUntilFormed(ros::Duration(bond_wait_time_)))
   {
     ROS_ERROR("Bond could not be formed to the VSC Settings Grabber!");
   }
   else
   {
-    bond.waitUntilBroken(ros::Duration(30.0));
+    bond.waitUntilBroken(ros::Duration(bond_break_time_));
     ROS_INFO("VSC Settings Grabber has broken the bond\n");
   }
 

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -346,6 +346,13 @@ int VscProcess::handleGetSettingInt(VscMsgType& recvMsg)
 
     if (recvMsg.msg.data[0] == VSC_SETUP_KEY_RADIO_POWER_LEVEL)
     {
+      std::stringstream ss;
+      for (size_t i = 0; i < recvMsg.msg.length; i++)
+      {
+          ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.data[i]);
+      }
+      ROS_INFO("Raw Data: %s", ss.str().c_str());
+      
       radio_power_level = recvMsg.msg.data[1] + 
                           recvMsg.msg.data[2] << 8 + 
                           recvMsg.msg.data[3] << 16 + 

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -326,6 +326,7 @@ int VscProcess::handleGetSettingInt(VscMsgType& recvMsg)
                           recvMsg.msg.data[4] << 24;
 
       have_radio_power_level = true;
+      ROS_INFO("Acquired VSC Radio Power Level");
     }
   }
   else
@@ -350,12 +351,14 @@ int VscProcess::handleGetSettingString(VscMsgType& recvMsg)
       serial = std::string(recvMsg.msg.data[1], VSC_SETTING_SERIAL_LENGTH);
 
       have_serial = true;
+      ROS_INFO("Acquired VSC Serial Number");
     }
     else if (recvMsg.msg.data[0] == VSC_SETUP_KEY_FIRMWARE)
     {
       firmware = std::string(recvMsg.msg.data[1], VSC_SETTING_FIRMWARE_LENGTH);
 
       have_firmware = true;
+      ROS_INFO("Acquired VSC Firmware Version");
     }
   }
   else

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -81,17 +81,17 @@ VscProcess::VscProcess() : myEStopState(0)
   vsc_scm_target_get(vscInterface);
 
   vsc_setup_unlock(vscInterface);
-  vsc_get_setting(vscInterface, VSC_SETUP_KEY_radio_power_db);
+  vsc_get_setting(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
   vsc_get_setting(vscInterface, VSC_SETUP_KEY_SERIAL);
   vsc_get_setting(vscInterface, VSC_SETUP_KEY_FIRMWARE);
 
   vsc_setup_unlock(vscInterface);
-  vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_radio_power_db);
+  vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_SERIAL);
   vsc_get_setting_int(vscInterface, VSC_SETUP_KEY_FIRMWARE);
 
   vsc_setup_unlock(vscInterface);
-  vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_radio_power_db);
+  vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_RADIO_POWER_LEVEL);
   vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_SERIAL);
   vsc_get_setting_string(vscInterface, VSC_SETUP_KEY_FIRMWARE);
 
@@ -337,7 +337,7 @@ int VscProcess::handleGetSettingInt(VscMsgType& recvMsg)
         ss << "\\x" << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(recvMsg.msg.buffer[i]);
     }
 
-    if (recvMsg.msg.data[0] == VSC_SETUP_KEY_radio_power_db)
+    if (recvMsg.msg.data[0] == VSC_SETUP_KEY_RADIO_POWER_LEVEL)
     {
       std::stringstream ss;
       for (size_t i = 0; i < recvMsg.msg.length; i++)

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -353,10 +353,7 @@ int VscProcess::handleGetSettingInt(VscMsgType& recvMsg)
       }
       ROS_INFO("Raw Data: %s", ss.str().c_str());
       
-      radio_power_level = recvMsg.msg.data[1] + 
-                          recvMsg.msg.data[2] << 8 + 
-                          recvMsg.msg.data[3] << 16 + 
-                          recvMsg.msg.data[4] << 24;
+      radio_power_level = recvMsg.msg.data[1] | (recvMsg.msg.data[2] << 8) | (recvMsg.msg.data[3] << 16) | (recvMsg.msg.data[4] << 24);
 
       have_radio_power_level = true;
       ROS_INFO("Acquired VSC Radio Power Level");
@@ -388,14 +385,14 @@ int VscProcess::handleGetSettingString(VscMsgType& recvMsg)
 
     if (recvMsg.msg.data[0] == VSC_SETUP_KEY_SERIAL)
     {
-      serial = std::string(recvMsg.msg.data[1], VSC_SETTING_SERIAL_LENGTH);
+      serial.assign(reinterpret_cast<const char*>(recvMsg.msg.data+1), VSC_SETTING_SERIAL_LENGTH);
 
       have_serial = true;
       ROS_INFO("Acquired VSC Serial Number");
     }
     else if (recvMsg.msg.data[0] == VSC_SETUP_KEY_FIRMWARE)
     {
-      firmware = std::string(recvMsg.msg.data[1], VSC_SETTING_FIRMWARE_LENGTH);
+      firmware.assign(reinterpret_cast<const char*>(recvMsg.msg.data+1), VSC_SETTING_FIRMWARE_LENGTH);
 
       have_firmware = true;
       ROS_INFO("Acquired VSC Firmware Version");

--- a/srv/GetVscSettings.srv
+++ b/srv/GetVscSettings.srv
@@ -2,4 +2,4 @@
 bool srv_ready
 string serial_number
 string firmware_version
-int16 radio_power_level
+int16 radio_power_level #in dB

--- a/srv/GetVscSettings.srv
+++ b/srv/GetVscSettings.srv
@@ -1,0 +1,4 @@
+---
+string serial_number
+string firmware_version
+int16 radio_power_level

--- a/srv/GetVscSettings.srv
+++ b/srv/GetVscSettings.srv
@@ -2,4 +2,4 @@
 bool srv_ready
 string serial_number
 string firmware_version
-int16 radio_power_level #in dB
+int16 radio_power_db

--- a/srv/GetVscSettings.srv
+++ b/srv/GetVscSettings.srv
@@ -1,4 +1,5 @@
 ---
+bool srv_ready
 string serial_number
 string firmware_version
 int16 radio_power_level

--- a/srv/GetVscSettings.srv
+++ b/srv/GetVscSettings.srv
@@ -2,4 +2,4 @@
 bool srv_ready
 string serial_number
 string firmware_version
-int16 radio_power_db
+int16 radio_power_db  # in dB


### PR DESCRIPTION
# VSC Hardware Native Settings Grabbing

---

* Ticket: [SC-24779](https://app.shortcut.com/greenzie/story/24779/vsc-hardware-firmware-settings-grab)
* Developer(s): @eyildirir

## Description
This PR is one side of a pair of PRs that bring support for reading settings off of the Fort Robotic VSCs and pushing the data onto Gazano as a hardware version. The other part for the `robotic-lawnmower` can be found here:
https://github.com/Greenzie/robotic-lawnmower/pull/3492

This PR is the part that interfaces with the Fort Robotics VSCs to get the settings on board and provide them to other ROS nodes through a rosservice.

## Changes
* Added functionality for unlocking setup mode on the VSC.
* Added message templates and wrapper functions for querying settings.
* Added message handling for received settings.
* Updated list of recognized serial messages.
* Added new service for reporting VSC settings.

## Checklist:
- [x] Tested PR in `GZDEV13`
- [x] Tested PR in `GZDEV8`
