### PR TITLE
Modified estop logging to occur only on state change

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-hri-safe-remote-control-system (0.2.0-focal3) focal; urgency=medium
+
+  * Modified ESTOP logging to occur only on state change
+
+ -- David Jensen <david@greenzie.com>  Wed, 05 Apr 2023 16:22:34 -0400
+
 ros-noetic-hri-safe-remote-control-system (0.2.0-focal2) focal; urgency=medium
 
   * VSC Disconnection Handling

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -332,6 +332,7 @@ int VscProcess::handleHeartbeatMsg(VscMsgType& recvMsg)
     // Updated previous values values
     prev_estop_vehicle = estop_vehicle;
     prev_estop_src = estop_src;
+    prev_estop_any = estop_any;
   }
   else
   {


### PR DESCRIPTION
This PR reduces the `ROS_WARN` messages when an ESTOP is engaged/active.

In the current behavior, a `ROS_WARN_THROTTLE` message is published with a period of 5 seconds. This can create spam in the main log output, but does have the benefit of continually reminding the viewer while the ESTOP is active.

The changes in this PR modify the logic to only print once immediately when an ESTOP becomes active or inactive. This provides the benefit of no longer continually filling up the log with messages about the ESTOP, and also more fine-grained timing of messages when each ESTOP becomes active or inactive.