### PR TITLE
Update Display Interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ add_service_files(
 add_message_files(
         DIRECTORY msg
         FILES
-        SrcDisplay.msg
         SrcHealth.msg
 )
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-hri-safe-remote-control-system (0.2.0-focal4) focal; urgency=medium
+
+  * Updated Display messaging interface
+
+ -- David Jensen <david@greenzie.com>  Tue, 07 Nov 2023 12:03:30 -0400
+
 ros-noetic-hri-safe-remote-control-system (0.2.0-focal3) focal; urgency=medium
 
   * Modified ESTOP logging to occur only on state change

--- a/include/hri_safe_remote_control_system/VscProcess.h
+++ b/include/hri_safe_remote_control_system/VscProcess.h
@@ -21,11 +21,11 @@
 #include "ros/ros.h"
 #include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
+#include <std_msgs/String.h>
 
 #include "hri_safe_remote_control_system/EmergencyStop.h"
 #include "hri_safe_remote_control_system/KeyValue.h"
 #include "hri_safe_remote_control_system/KeyString.h"
-#include "hri_safe_remote_control_system/SrcDisplay.h"
 #include "hri_safe_remote_control_system/SrcHealth.h"
 
 #include "hri_safe_remote_control_system/GetVscSettings.h"
@@ -69,9 +69,11 @@ public:
   bool vscSettingsSrv(GetVscSettings::Request &req, GetVscSettings::Response &res);
 
   void receivedVibration(const std_msgs::Bool msg);
-  void receivedDisplayOnCommand(const hri_safe_remote_control_system::SrcDisplay& msg);
+  void receivedDisplayOnCommand1(const std_msgs::StringConstPtr& msg);
+  void receivedDisplayOnCommand2(const std_msgs::StringConstPtr& msg);
+  void receivedDisplayOnCommand3(const std_msgs::StringConstPtr& msg);
+  void receivedDisplayOnCommand4(const std_msgs::StringConstPtr& msg);
   void receivedDisplayOffCommand(const std_msgs::EmptyConstPtr& msg);
-  void checkCharacterLimit(const hri_safe_remote_control_system::SrcDisplay& msg);
 
 private:
   void readFromVehicle();
@@ -110,7 +112,10 @@ private:
   ros::Publisher estopPub;
   ros::Publisher srcHealthPub;
   ros::Subscriber vibrateSrcSub;
-  ros::Subscriber displaySrcOnSub;
+  ros::Subscriber displaySrcOnSub1; // Top Row
+  ros::Subscriber displaySrcOnSub2; // Second from Top
+  ros::Subscriber displaySrcOnSub3; // Third from Top
+  ros::Subscriber displaySrcOnSub4; // Bottom Row
   ros::Subscriber displaySrcOffSub;
   ros::Time lastDataRx, lastTxTime, lastRemoteStatusRxTime, lastReconnectAttempt;
 

--- a/msg/SrcDisplay.msg
+++ b/msg/SrcDisplay.msg
@@ -1,5 +1,0 @@
-int8 MAXCHARACTERS = 20
-string displayrow1
-string displayrow2
-string displayrow3
-string displayrow4

--- a/src/VscProcess.cpp
+++ b/src/VscProcess.cpp
@@ -105,7 +105,10 @@ VscProcess::VscProcess() : myEStopState(0)
 
   // Subscribe for SRC actions
   vibrateSrcSub = rosNode.subscribe("/src_vibrate", 1, &VscProcess::receivedVibration, this);
-  displaySrcOnSub = rosNode.subscribe("/src_display_mode_on", 1, &VscProcess::receivedDisplayOnCommand, this);
+  displaySrcOnSub1 = rosNode.subscribe("/src_display_mode_on_1", 1, &VscProcess::receivedDisplayOnCommand1, this);
+  displaySrcOnSub2 = rosNode.subscribe("/src_display_mode_on_2", 1, &VscProcess::receivedDisplayOnCommand2, this);
+  displaySrcOnSub3 = rosNode.subscribe("/src_display_mode_on_3", 1, &VscProcess::receivedDisplayOnCommand3, this);
+  displaySrcOnSub4 = rosNode.subscribe("/src_display_mode_on_4", 1, &VscProcess::receivedDisplayOnCommand4, this);
   displaySrcOffSub = rosNode.subscribe("/src_display_mode_off", 1, &VscProcess::receivedDisplayOffCommand, this);
 
   // Main Loop Timer Callback
@@ -146,28 +149,7 @@ void VscProcess::receivedVibration(const std_msgs::Bool msg)
   }
 }
 
-void VscProcess::checkCharacterLimit(const hri_safe_remote_control_system::SrcDisplay& msg)
-{
-  // Check if display message is above MAXCHARACTERS for a row in SRC display
-  if (msg.displayrow1.size() > msg.MAXCHARACTERS)
-  {
-    ROS_WARN("Maximum characters limit reached for display row 1. Please enter upto 20 characters.");
-  }
-  if (msg.displayrow2.size() > msg.MAXCHARACTERS)
-  {
-    ROS_WARN("Maximum characters limit reached for display row 2. Please enter upto 20 characters.");
-  }
-  if (msg.displayrow3.size() > msg.MAXCHARACTERS)
-  {
-    ROS_WARN("Maximum characters limit reached for display row 3. Please enter upto 20 characters.");
-  }
-  if (msg.displayrow4.size() > msg.MAXCHARACTERS)
-  {
-    ROS_WARN("Maximum characters limit reached for display row 4. Please enter upto 20 characters.");
-  }
-}
-
-void VscProcess::receivedDisplayOnCommand(const hri_safe_remote_control_system::SrcDisplay& msg)
+void VscProcess::receivedDisplayOnCommand1(const std_msgs::StringConstPtr& msg)
 {
   if (vscInterface == NULL)
   {
@@ -176,30 +158,60 @@ void VscProcess::receivedDisplayOnCommand(const hri_safe_remote_control_system::
   // Turn on custom display mode
   vsc_send_user_feedback(vscInterface, VSC_USER_DISPLAY_MODE, DISPLAY_MODE_CUSTOM_TEXT);
 
-  // Checks if the display messages are below the MAXCHARACTERS limit
-  checkCharacterLimit(msg);
+  // Update Display message
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_1, msg->data.c_str());
+}
 
-  // Update Display messages
-  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_1, msg.displayrow1.c_str());
-  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_2, msg.displayrow2.c_str());
-  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_3, msg.displayrow3.c_str());
-  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_4, msg.displayrow4.c_str());
+void VscProcess::receivedDisplayOnCommand2(const std_msgs::StringConstPtr& msg)
+{
+  if (vscInterface == NULL)
+  {
+    return;
+  }
+  // Turn on custom display mode
+  vsc_send_user_feedback(vscInterface, VSC_USER_DISPLAY_MODE, DISPLAY_MODE_CUSTOM_TEXT);
+
+  // Update Display message
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_2, msg->data.c_str());
+}
+
+void VscProcess::receivedDisplayOnCommand3(const std_msgs::StringConstPtr& msg)
+{
+  if (vscInterface == NULL)
+  {
+    return;
+  }
+  // Turn on custom display mode
+  vsc_send_user_feedback(vscInterface, VSC_USER_DISPLAY_MODE, DISPLAY_MODE_CUSTOM_TEXT);
+
+  // Update Display message
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_3, msg->data.c_str());
+}
+
+void VscProcess::receivedDisplayOnCommand4(const std_msgs::StringConstPtr& msg)
+{
+  if (vscInterface == NULL)
+  {
+    return;
+  }
+  // Turn on custom display mode
+  vsc_send_user_feedback(vscInterface, VSC_USER_DISPLAY_MODE, DISPLAY_MODE_CUSTOM_TEXT);
+
+  // Update Display message
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_4, msg->data.c_str());
 }
 
 void VscProcess::receivedDisplayOffCommand(const std_msgs::EmptyConstPtr& msg)
 {
-  hri_safe_remote_control_system::SrcDisplay clear_msg;
-  clear_msg.displayrow1 = clear_msg.displayrow2 = clear_msg.displayrow3 = clear_msg.displayrow4 = "";
-  
   if (vscInterface == NULL)
   {
     return;
   }
 
-  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_1, clear_msg.displayrow1.c_str());
-  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_2, clear_msg.displayrow2.c_str());
-  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_3, clear_msg.displayrow3.c_str());
-  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_4, clear_msg.displayrow4.c_str());
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_1, "");
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_2, "");
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_3, "");
+  vsc_send_user_feedback_string(vscInterface, VSC_USER_DISPLAY_ROW_4, "");
   vsc_send_user_feedback(vscInterface, VSC_USER_DISPLAY_MODE, DISPLAY_MODE_STANDARD);
 }
 


### PR DESCRIPTION
This PR updates the ROS interface used to send messages for display on an SRC.

Instead of using a custom message for the display text, there are 4 topics, one for each display row, using the `std_msgs::String` type instead.

Making this change allows a developer to write their node in such a way that it does not have a build dependency on this package, while still being able to interface with it.