### PR TITLE
Add CircleCI config for automated debian build and deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,17 +35,6 @@ workflows:
       - *build_amd
       - *build_arm
 
-      - greenzie/debian_deploy_experimental:
-          name: "deploy_all_greenzie"
-          context: GREENZIE
-          filters:
-            branches:
-              only:
-                - << pipeline.parameters.filter-branch >>
-          requires:
-            - amd_debian_build
-            - arm64_debian_build
-
   manualdeploy:
     when: << pipeline.parameters.manual-deploy >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,39 +7,42 @@ parameters:
   manual-deploy:
     type: boolean
     default: false
-  filter-branch:
-    type: string
-    default: noetic
-
-_build_amd: &build_amd
-  greenzie/debian_build_simple:
-    name: "amd_debian_build"
-    context: GREENZIE
-    platform: amd64
-    executor: greenzie/debianize_amd64
-    generate_changelog: false
-
-_build_arm: &build_arm
-  greenzie/debian_build_simple:
-    name: "arm64_debian_build"
-    context: GREENZIE
-    platform: arm64
-    executor: greenzie/debianize_arm64
-    generate_changelog: false
 
 workflows:
   version: 2
   pushbuild:
     unless: << pipeline.parameters.manual-deploy >>
     jobs:
-      - *build_amd
-      - *build_arm
+      - greenzie/debian_build_simple:
+          name: "amd_debian_build"
+          context: GREENZIE
+          platform: amd64
+          executor: greenzie/debianize_amd64
+          generate_changelog: false
+
+      - greenzie/debian_build_simple:
+          name: "arm64_debian_build"
+          context: GREENZIE
+          platform: arm64
+          executor: greenzie/debianize_arm64
+          generate_changelog: false
 
   manualdeploy:
     when: << pipeline.parameters.manual-deploy >>
     jobs:
-      - *build_amd
-      - *build_arm
+      - greenzie/debian_build_simple:
+          name: "amd_debian_build"
+          context: GREENZIE
+          platform: amd64
+          executor: greenzie/debianize_amd64
+          generate_changelog: false
+
+      - greenzie/debian_build_simple:
+          name: "arm64_debian_build"
+          context: GREENZIE
+          platform: arm64
+          executor: greenzie/debianize_arm64
+          generate_changelog: false
 
       - greenzie/debian_deploy_experimental:
           name: "deploy_all_greenzie"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,60 @@
+version: 2.1
+
+orbs:
+  greenzie: greenzie/build_and_publish_debs@dev:volatile
+
+parameters:
+  manual-deploy:
+    type: boolean
+    default: false
+  filter-branch:
+    type: string
+    default: noetic
+
+_build_amd: &build_amd
+  greenzie/debian_build_simple:
+    name: "amd_debian_build"
+    context: GREENZIE
+    platform: amd64
+    executor: greenzie/debianize_amd64
+    generate_changelog: false
+
+_build_arm: &build_arm
+  greenzie/debian_build_simple:
+    name: "arm64_debian_build"
+    context: GREENZIE
+    platform: arm64
+    executor: greenzie/debianize_arm64
+    generate_changelog: false
+
+workflows:
+  version: 2
+  pushbuild:
+    unless: << pipeline.parameters.manual-deploy >>
+    jobs:
+      - *build_amd
+      - *build_arm
+
+      - greenzie/debian_deploy_experimental:
+          name: "deploy_all_greenzie"
+          context: GREENZIE
+          filters:
+            branches:
+              only:
+                - << pipeline.parameters.filter-branch >>
+          requires:
+            - amd_debian_build
+            - arm64_debian_build
+
+  manualdeploy:
+    when: << pipeline.parameters.manual-deploy >>
+    jobs:
+      - *build_amd
+      - *build_arm
+
+      - greenzie/debian_deploy_experimental:
+          name: "deploy_all_greenzie"
+          context: GREENZIE
+          requires:
+            - amd_debian_build
+            - arm64_debian_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@dev:volatile
+  greenzie: greenzie/build_and_publish_debs@0.1.1
 
 parameters:
   manual-deploy:

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Syncs changes from upstream (jstanhope3/hri-safe-remote-control-system) into a
+# review branch targeting our 'noetic' branch.
+#
+# Usage:
+#   ./scripts/sync-upstream.sh          # dry run: show what would happen
+#   ./scripts/sync-upstream.sh --run    # execute the sync
+#
+# Background:
+#   This repo is a private mirror of jstanhope3/hri-safe-remote-control-system,
+#   itself a fork of humanisticrobotics/hri-safe-remote-control-system.
+#   Our working branch is 'noetic' (ROS Noetic port); upstream only has 'master'.
+#
+# What --run does:
+#   1. Ensures the 'upstream' remote is configured.
+#   2. Fetches from upstream.
+#   3. Creates a dated branch off 'noetic'.
+#   4. Attempts a merge of upstream/master.
+#      - If clean: pushes the branch and opens (or links) a PR toward 'noetic'.
+#      - If conflicts: aborts and lists the conflicting files so the developer
+#        can resolve them locally before re-running with --run.
+set -euo pipefail
+
+UPSTREAM_REMOTE="upstream"
+UPSTREAM_URL="https://github.com/jstanhope3/hri-safe-remote-control-system.git"
+BASE_BRANCH="noetic"
+ORIGIN_REPO="Greenzie/hri-safe-remote-control-system"
+SYNC_BRANCH="upstream-sync-$(date +%Y%m%d)"
+DRY_RUN=true
+
+for arg in "$@"; do
+    case "$arg" in
+        --run) DRY_RUN=false ;;
+        *) echo "error: unknown argument '$arg'" >&2; exit 1 ;;
+    esac
+done
+
+# Print a command; execute it only when not in dry-run mode.
+step() {
+    echo "+ $*"
+    if [ "$DRY_RUN" = false ]; then
+        "$@"
+    fi
+}
+
+# --- 1. Ensure upstream remote exists ---
+if ! git remote get-url "$UPSTREAM_REMOTE" &>/dev/null; then
+    step git remote add "$UPSTREAM_REMOTE" "$UPSTREAM_URL"
+fi
+
+# --- 2. Fetch upstream (always, so the comparison below is current) ---
+echo "Fetching $UPSTREAM_REMOTE..."
+if [ "$DRY_RUN" = false ]; then
+    git fetch "$UPSTREAM_REMOTE" --quiet
+else
+    git fetch "$UPSTREAM_REMOTE" --quiet 2>/dev/null || true
+fi
+
+# --- 3. Check for new commits ---
+new_commits=$(git log --oneline "$UPSTREAM_REMOTE/master" ^"$BASE_BRANCH")
+if [ -z "$new_commits" ]; then
+    echo "$BASE_BRANCH is already up to date with $UPSTREAM_REMOTE/master."
+    exit 0
+fi
+
+count=$(echo "$new_commits" | wc -l)
+echo ""
+echo "$count new commit(s) in $UPSTREAM_REMOTE/master not present in $BASE_BRANCH:"
+echo "$new_commits"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo "Dry run -- would execute:"
+    echo ""
+    step git checkout -b "$SYNC_BRANCH" "$BASE_BRANCH"
+    step git merge "$UPSTREAM_REMOTE/master"
+    step git push origin "$SYNC_BRANCH"
+    echo ""
+    echo "Re-run with --run to execute."
+    exit 0
+fi
+
+# --- 4. Create sync branch and attempt merge ---
+git checkout -b "$SYNC_BRANCH" "$BASE_BRANCH"
+echo "+ git merge $UPSTREAM_REMOTE/master"
+
+if ! git merge "$UPSTREAM_REMOTE/master" --no-commit --no-ff 2>/dev/null; then
+    conflicting=$(git diff --name-only --diff-filter=U)
+    echo ""
+    echo "Merge has conflicts in the following file(s):"
+    while IFS= read -r f; do printf '  %s\n' "$f"; done <<< "$conflicting"
+    echo ""
+    echo "Resolve the conflicts locally, then:"
+    echo "  git add <files>"
+    echo "  git merge --continue"
+    echo "  git push origin $SYNC_BRANCH"
+    git merge --abort
+    git checkout "$BASE_BRANCH"
+    git branch -D "$SYNC_BRANCH"
+    exit 1
+fi
+
+# No conflicts -- commit and push.
+git commit --no-edit
+echo "+ git push origin $SYNC_BRANCH"
+git push origin "$SYNC_BRANCH"
+
+# --- 5. Open or link PR ---
+echo ""
+if command -v gh &>/dev/null; then
+    gh pr create \
+        --repo "$ORIGIN_REPO" \
+        --base "$BASE_BRANCH" \
+        --head "$SYNC_BRANCH" \
+        --title "Sync upstream ($count commit(s))" \
+        --body "$(printf "Automated upstream sync from \`%s/master\`.\n\n## Commits\n\n\`\`\`\n%s\n\`\`\`" "$UPSTREAM_REMOTE" "$new_commits")"
+else
+    echo "gh not found. Open the PR at:"
+    echo "  https://github.com/$ORIGIN_REPO/compare/$BASE_BRANCH...$SYNC_BRANCH"
+fi


### PR DESCRIPTION
## Summary

- Adds `.circleci/config.yml` using the `greenzie/build_and_publish_debs` orb
- Enables automated amd64 + arm64 debian builds and deploy to `greenzie-experimental` and bobcat on every push to `noetic`
- Prerequisite for removing `hri-safe-remote-control-system` as a git submodule from `robotic-lawnmower` (sc-50476)

## Config choices

- `clone_submodules: false` -- this repo has no submodules
- `source_folder: "."` -- package lives at repo root, not in `src/`
- `generate_changelog: false` -- `debian/changelog` is maintained manually (focal1..focal5 scheme); using `greenzie-release changelog` would generate incompatible date-suffix entries

## Notes

- Currently pinned to `dev:volatile` orb while the build is verified. Will be updated to `0.1.1` before merging to `noetic`.
- Before merging to `noetic`, a new `debian/changelog` entry (`0.2.0-focal6`) must be added so the first automated deploy produces a fresh version.

[sc-50476]

## Test plan

- [x] `amd_debian_build` job passes on this branch
- [x] `arm64_debian_build` job passes on this branch
- [x] Update orb pin from `dev:volatile` to `0.1.1` once promoted
- [x] Add `debian/changelog` entry `0.2.0-focal6` before merge
- [x] Merge to `noetic` and confirm deploy to greenzie-experimental succeeds